### PR TITLE
feat: Implement view-only access for FRAC and Playlist features

### DIFF
--- a/project/ws/app/src/lib/routes/frac/FRAC_AND_POSITIONS_USER_GUIDE.md
+++ b/project/ws/app/src/lib/routes/frac/FRAC_AND_POSITIONS_USER_GUIDE.md
@@ -1,0 +1,180 @@
+# FRAC & Manage Positions — User Journey Guide
+
+**FRAC** stands for **F**ramework of **R**oles, **A**ctivities, and **C**ompetencies. It's where an admin builds the org's skill structure: upload the building blocks, then link them together so every position knows what its people must be able to do.
+
+**Manage Positions** is where you see those links assembled — each position with its full Role → Activity → Competency tree.
+
+This guide covers every screen end-to-end: **what** it is, **why** it exists, **how** to use it.
+
+---
+
+## The Big Picture
+
+FRAC has four building blocks that stack into a chain:
+
+```
+Competency  ─ the skill (with 5 levels)
+Activity    ─ a task that needs competencies
+Role        ─ a responsibility made of activities
+Position    ─ a job that holds roles
+
+Chain:  Position → Role → Activity → Competency (L1–L5)
+```
+
+You work in two passes:
+
+1. **Upload** each block (Competency, Activity, Role) from a CSV/Excel file.
+2. **Map** them together, bottom-up: Activity→Competency, then Role→Activity, then Role→Position.
+
+Once mapped, **Manage Positions** shows the finished hierarchy, and **Playlist** uses it to decide what learners see.
+
+---
+
+## Screen 1 — FRAC Hub ("Welcome to the FRAC")
+
+**Route:** `/app/home/frac/dashboard`
+
+- **What:** The FRAC home page with 6 cards — 3 for uploading blocks, 3 for mapping them.
+- **Why:** One launchpad for the whole framework. Top row builds blocks, bottom row connects them.
+- **How:** Each card has buttons:
+
+| Card | Buttons | Goes to |
+|------|---------|---------|
+| **Upload Competency** | Upload / Manage | Upload or edit competencies |
+| **Upload Activities** | Upload / Manage | Upload or edit activities |
+| **Upload Roles** | Upload / Manage | Upload or edit roles |
+| **Map Activities to Competencies** | Map now | Link activities ↔ competency levels |
+| **Map Roles to Activities** | Map now | Link roles ↔ activities |
+| **Map Roles to Positions** | Map now | Link positions ↔ roles |
+
+> First-time setup order: upload all three blocks first, then map bottom-up (Activity→Competency, Role→Activity, Role→Position).
+
+---
+
+## Uploading Blocks
+
+The **Upload** and **Manage** screens look the same for Competency, Activity, and Role — only the columns differ.
+
+### Upload screen (Upload Competency / Activity / Role / Positions)
+
+**Route:** `/app/home/frac/competency?mode=upload` (and `activity`, `role`, `position`)
+
+- **What:** A page with a **Download sample** button, an **Upload File** button, and a drag-and-drop modal.
+- **Why:** Bulk-add many items at once from a spreadsheet instead of typing them in.
+- **How:**
+  1. Pick the **Language** (English or Hindi).
+  2. Click **Download sample** to get the correctly-formatted template.
+  3. Fill it in, then **Upload File** → drag-drop or browse → **Confirm & Upload**.
+  4. A result popup confirms how many records loaded; you land on the **Manage** view.
+
+> Competency/Activity/Role accept CSV or XLSX. Positions accept CSV or JSON. Always start from the downloaded sample so the columns match.
+
+### Manage screen (Manage Competency / Activity / Role)
+
+**Route:** `/app/home/frac/competency?mode=manage` (and `activity`, `role`)
+
+- **What:** A table of everything uploaded — Code + Name (Competency also shows Description, Type, Area, and Level 1–5 labels).
+- **Why:** Review, fix typos, or delete items after upload.
+- **How:** Search by name/code, switch Language to view translations, then:
+  - **Edit** → tick a row, edit cells inline, click **Save**.
+  - **Remove** → tick rows and delete (with confirmation).
+
+> The Language dropdown here **views** translations. To add or change mappings later, you edit in **English** (see the language note below).
+
+---
+
+## Mapping Blocks Together
+
+All three map screens share one layout: **pick an item on the left, tick what it links to on the right, click Add.**
+
+> **Language rule (all map screens):** mapping is only editable in **English**. In Hindi you'll see a banner — *"You are currently viewing mappings for Hindi. To make changes, please switch to English."* — and the screen is read-only.
+
+### Screen — Map Activities to Competencies
+
+**Route:** `/app/home/frac/map-activity`
+
+- **What:** Left: list of Activities. Right: Competencies with **Level 1–5** checkboxes.
+- **Why:** Defines which competency levels each task builds. This is the foundation the other maps depend on.
+- **How:** Click an activity → tick the competency levels it needs → **Add Competency**. Repeat per activity. ("Activity not selected" shows until you pick one.)
+
+### Screen — Map Roles to Activities
+
+**Route:** `/app/home/frac/map-role`
+
+- **What:** Left: list of Roles (expandable to show mapped activities). Right: Available Activities checkboxes.
+- **Why:** Defines what each role is responsible for doing.
+- **How:** Click a role → tick its activities → **Add activity**.
+
+> If you try to add an activity that has **no competency mapping yet**, a popup blocks you and offers **Map Now** to fix it first. Map Activity→Competency before Role→Activity.
+
+### Screen — Map Roles to Positions
+
+**Route:** `/app/home/frac/map-role-position`
+
+- **What:** Left: list of Positions. Right: Available Roles checkboxes.
+- **Why:** Attaches roles to real job positions — the top of the chain. This is what makes a position "complete".
+- **How:** Click a position → tick its roles → **Add Role**. ("Position not selected" shows until you pick one.)
+
+---
+
+## Manage Positions
+
+A separate **Manage Positions** item in the left nav — the read-and-edit home for positions and their assembled hierarchy.
+
+### Screen — Manage Position (card grid)
+
+**Route:** `/app/home/frac/position`
+
+- **What:** A grid of position cards, each showing its **Roles / Activities / Competencies** counts. Top bar has Language, **Upload Position**, and **Manage Position**.
+- **Why:** At-a-glance view of how built-out each position is (0 counts = nothing mapped yet).
+- **How:** On any card:
+  - **View** → opens the full **Role → Activity → Competency** tree (with L1–L5 badges).
+  - **Edit** → change the position's details.
+  - Top buttons: **Upload Position** (bulk add) or **Manage Position** (edit the list).
+
+### Screen — Manage Position (table)
+
+**Route:** `/app/home/frac/position?mode=manage`
+
+- **What:** A table of positions (P1, P2…) with Code + Name, Search, Language, Remove + Edit.
+- **Why:** Rename or delete positions in bulk.
+- **How:** Search/filter, tick rows, **Edit** inline or **Remove**, then **Save**.
+
+### Screen — Upload Positions
+
+**Route:** `/app/home/frac/position?mode=upload`
+
+- **What:** Same upload pattern — Download sample, Upload File, drag-drop modal (CSV or JSON).
+- **Why:** Add many positions at once.
+- **How:** Download sample → fill → Upload File → Confirm & Upload → land on the card grid.
+
+---
+
+## The View Modal (read-only)
+
+Opened by **View** on a position card.
+
+- **What:** A popup titled with the position name, summarising its **Roles / Activities / Competencies** counts, then an expandable tree.
+- **Why:** Verify the full chain is wired correctly before learners rely on it.
+- **How:** Expand **Role → Activity → Competency**; each competency shows its mapped levels (e.g. **L1–L5**). Read-only — close when done.
+
+---
+
+## Quick End-to-End: Build a Position from Scratch
+
+1. **FRAC Hub** → upload **Competencies**, **Activities**, **Roles** (Download sample → fill → Upload).
+2. **Map Activities to Competencies** → tick L1–L5 per activity → Add Competency.
+3. **Map Roles to Activities** → tick activities per role → Add activity.
+4. **Map Roles to Positions** → tick roles per position → Add Role.
+5. **Manage Positions** → open the card → **View** to confirm the full tree.
+6. Position is ready — **Playlist** can now use it to serve learners.
+
+---
+
+## Good to Know
+
+- **Order matters bottom-up** — Competency → Activity → Role → Position. The system blocks Role→Activity if an activity has no competency yet.
+- **Edit in English** — all mapping is done in English; other languages are view-only translations.
+- **Always start from the sample file** — column names must match or the upload fails.
+- **Counts tell the story** — a position card showing `0 Roles / 0 Activities / 0 Competencies` simply hasn't been mapped yet.
+- **Leaving with unsaved edits** prompts a confirmation so you don't lose work.

--- a/project/ws/app/src/lib/routes/frac/components/activity-mapping-table/activity-mapping-table.component.html
+++ b/project/ws/app/src/lib/routes/frac/components/activity-mapping-table/activity-mapping-table.component.html
@@ -4,11 +4,14 @@
     <div class="title-bar">Available Activities</div>
 
     <div class="button-group">
-      <button *ngIf="!isReadOnly" mat-raised-button class="app-btn primary" [disabled]="isAddDisabled()"
-        (click)="onAddActivity()">
-        <mat-spinner *ngIf="isSaving" class="btn-spinner" [diameter]="16" [strokeWidth]="2"></mat-spinner>
-        {{ isSaving ? 'Saving...' : 'Add activity' }}
-      </button>
+      <ng-container *ngIf="!isReadOnly">
+        <!-- Add button - hidden for view-only -->
+        <button mat-raised-button class="app-btn primary" [disabled]="isAddDisabled()"
+          (click)="onAddActivity()" *appHideForViewOnly>
+          <mat-spinner *ngIf="isSaving" class="btn-spinner" [diameter]="16" [strokeWidth]="2"></mat-spinner>
+          {{ isSaving ? 'Saving...' : 'Add activity' }}
+        </button>
+      </ng-container>
     </div>
   </div>
 
@@ -53,7 +56,7 @@
         <ng-container *ngIf="!isLoading">
           <div class="activity-row" *ngFor="let a of filteredActivities">
             <div class="check-cell">
-              <mat-checkbox [checked]="isChecked(a.code)" [disabled]="isReadOnly"
+              <mat-checkbox [checked]="isChecked(a.code)" [disabled]="isReadOnly" appDisableForViewOnly
                 (change)="onCheckboxChange(a.code, $event.checked)">
               </mat-checkbox>
             </div>

--- a/project/ws/app/src/lib/routes/frac/components/competency-mapping-table/competency-mapping-table.component.html
+++ b/project/ws/app/src/lib/routes/frac/components/competency-mapping-table/competency-mapping-table.component.html
@@ -5,10 +5,13 @@
     <div class="title-bar">Available Competencies</div>
 
     <div class="button-group">
-      <button *ngIf="!isReadOnly" mat-raised-button class="app-btn primary" [disabled]="isAddDisabled()"
-        (click)="onAddCompetency()">
-        {{ isSaving ? 'Saving...' : 'Add Competency' }}
-      </button>
+      <ng-container *ngIf="!isReadOnly">
+        <!-- Add button - hidden for view-only -->
+        <button mat-raised-button class="app-btn primary" [disabled]="isAddDisabled()"
+          (click)="onAddCompetency()" *appHideForViewOnly>
+          {{ isSaving ? 'Saving...' : 'Add Competency' }}
+        </button>
+      </ng-container>
     </div>
   </div>
 
@@ -64,7 +67,7 @@
 
               <!-- Dynamic Level Checkboxes -->
               <div class="cell checkbox-cell" *ngFor="let lvl of displayLevels">
-                <mat-checkbox [checked]="isChecked(c.code, c.code + '_' + lvl)" [disabled]="isReadOnly"
+                <mat-checkbox [checked]="isChecked(c.code, c.code + '_' + lvl)" [disabled]="isReadOnly" appDisableForViewOnly
                   (change)="checkChange(c.code, c.code + '_' + lvl, $event.checked)">
                 </mat-checkbox>
               </div>

--- a/project/ws/app/src/lib/routes/frac/components/frac-table/frac-table.component.html
+++ b/project/ws/app/src/lib/routes/frac/components/frac-table/frac-table.component.html
@@ -5,7 +5,7 @@
       <th mat-header-cell *matHeaderCellDef style="width: 50px;"></th>
       <td mat-cell *matCellDef="let row" style="width: 50px;">
         <mat-checkbox (click)="$event.stopPropagation()" (change)="onRowSelect(row)"
-          [checked]="selection.isSelected(row)" [aria-label]="checkboxLabel(row)">
+          [checked]="selection.isSelected(row)" [aria-label]="checkboxLabel(row)" appDisableForViewOnly>
         </mat-checkbox>
       </td>
     </ng-container>

--- a/project/ws/app/src/lib/routes/frac/components/frac-upload/frac-upload-popup.component.html
+++ b/project/ws/app/src/lib/routes/frac/components/frac-upload/frac-upload-popup.component.html
@@ -79,7 +79,8 @@
       (click)="onConfirmUpload()">
       {{ config.actions?.primary?.label || 'Confirm & Upload' }}
     </button> -->
-    <button mat-stroked-button class="upload-btn" [disabled]="!selectedFile" (click)="onConfirmUpload()">
+    <button mat-stroked-button class="upload-btn" [disabled]="!selectedFile" (click)="onConfirmUpload()"
+      *appHideForViewOnly>
       {{ config.actions?.primary?.label || 'Confirm & Upload' }}
     </button>
   </div>

--- a/project/ws/app/src/lib/routes/frac/components/role-mapping-table/role-mapping-table.component.html
+++ b/project/ws/app/src/lib/routes/frac/components/role-mapping-table/role-mapping-table.component.html
@@ -4,11 +4,14 @@
     <div class="title-bar">Available Roles</div>
 
     <div class="button-group">
-      <button *ngIf="!isReadOnly" mat-raised-button class="app-btn primary" [disabled]="isAddDisabled()"
-        (click)="onAddPosition()">
-        <mat-spinner *ngIf="isSaving" class="btn-spinner" [diameter]="16" [strokeWidth]="2"></mat-spinner>
-        {{ isSaving ? 'Saving...' : 'Add Role' }}
-      </button>
+      <ng-container *ngIf="!isReadOnly">
+        <!-- Add button - hidden for view-only -->
+        <button mat-raised-button class="app-btn primary" [disabled]="isAddDisabled()"
+          (click)="onAddPosition()" *appHideForViewOnly>
+          <mat-spinner *ngIf="isSaving" class="btn-spinner" [diameter]="16" [strokeWidth]="2"></mat-spinner>
+          {{ isSaving ? 'Saving...' : 'Add Role' }}
+        </button>
+      </ng-container>
     </div>
   </div>
 
@@ -53,7 +56,7 @@
         <ng-container *ngIf="!isLoading">
           <div class="position-row" *ngFor="let p of filteredPositions">
             <div class="check-cell">
-              <mat-checkbox [checked]="isChecked(p.code)" [disabled]="isReadOnly"
+              <mat-checkbox [checked]="isChecked(p.code)" [disabled]="isReadOnly" appDisableForViewOnly
                 (change)="onCheckboxChange(p.code, $event.checked)">
               </mat-checkbox>
             </div>

--- a/project/ws/app/src/lib/routes/frac/components/upload-activity-list-table/upload-activity-list-table.component.html
+++ b/project/ws/app/src/lib/routes/frac/components/upload-activity-list-table/upload-activity-list-table.component.html
@@ -8,7 +8,7 @@
       <td mat-cell *matCellDef="let row" style="width: 50px;">
         <ng-container *ngIf="!isLoading">
           <mat-checkbox (click)="$event.stopPropagation()" (change)="onRowSelect(row)" (keydown)="onRowSelect(row)"
-            [checked]="selection.isSelected(row)" [aria-label]="checkboxLabel(row)">
+            [checked]="selection.isSelected(row)" [aria-label]="checkboxLabel(row)" appDisableForViewOnly>
           </mat-checkbox>
         </ng-container>
         <div *ngIf="isLoading" class="shimmer-box checkbox"></div>

--- a/project/ws/app/src/lib/routes/frac/components/upload-competency-list-table/upload-competency-list-table.component.html
+++ b/project/ws/app/src/lib/routes/frac/components/upload-competency-list-table/upload-competency-list-table.component.html
@@ -10,7 +10,7 @@
         <td mat-cell *matCellDef="let row">
           <ng-container *ngIf="!isLoading">
             <mat-checkbox (click)="$event.stopPropagation()" (change)="onRowSelect(row)" (keydown)="onRowSelect(row)"
-              [checked]="selection.isSelected(row)" [aria-label]="checkboxLabel(row)">
+              [checked]="selection.isSelected(row)" [aria-label]="checkboxLabel(row)" appDisableForViewOnly>
             </mat-checkbox>
           </ng-container>
           <!-- Shimmer cell -->

--- a/project/ws/app/src/lib/routes/frac/frac.module.ts
+++ b/project/ws/app/src/lib/routes/frac/frac.module.ts
@@ -63,6 +63,9 @@ import { UnsavedChangesModalComponent } from './components/unsaved-changes-modal
 import { HierarchyChipDetailsModalComponent } from './components/hierarchy-chip-details-modal/hierarchy-chip-details-modal.component'
 import { PositionHierarchyViewModalComponent } from './components/position-hierarchy-view-modal/position-hierarchy-view-modal.component'
 import { FracApiErrorNormalizerInterceptor } from './interceptors/frac-api-error-normalizer.interceptor'
+import { HideForViewOnlyDirective } from '../../shared/directives/hide-for-view-only.directive'
+import { DisableForViewOnlyDirective } from '../../shared/directives/disable-for-view-only.directive'
+import { FEATURE_KEY } from '../../shared/access/feature-access'
 
 
 @NgModule({
@@ -124,7 +127,11 @@ import { FracApiErrorNormalizerInterceptor } from './interceptors/frac-api-error
     MatSelectModule,
     MatCheckboxModule,
     MatDialogModule,
-    MatSnackBarModule
+    MatSnackBarModule,
+
+    // ✅ Standalone directives
+    HideForViewOnlyDirective,
+    DisableForViewOnlyDirective,
 
   ],
   exports: [
@@ -137,6 +144,8 @@ import { FracApiErrorNormalizerInterceptor } from './interceptors/frac-api-error
       useClass: FracApiErrorNormalizerInterceptor,
       multi: true,
     },
+    // Tells view-only directives in this module they render inside the FRAC feature.
+    { provide: FEATURE_KEY, useValue: 'frac' },
   ]
 })
 export class FracModule { }

--- a/project/ws/app/src/lib/routes/frac/pages/activity/activity-upload/activity-upload.component.html
+++ b/project/ws/app/src/lib/routes/frac/pages/activity/activity-upload/activity-upload.component.html
@@ -5,11 +5,13 @@
     <span>Back</span>
   </button>
 
-  <button class="save-btn" (click)="onSaveClicked()" *ngIf="routeMode === 'manage'"
-    [disabled]="!isEditing || !hasTableData() || isUpdating || !hasPendingTableChanges()">
-    <mat-spinner *ngIf="isUpdating" class="btn-spinner" [diameter]="16" [strokeWidth]="2"></mat-spinner>
-    <span style="color: white;">{{ isUpdating ? uiConfig.labels.saving : uiConfig.labels.save }}</span>
-  </button>
+  <ng-container *ngIf="routeMode === 'manage'">
+    <button class="save-btn" (click)="onSaveClicked()" *appHideForViewOnly
+      [disabled]="!isEditing || !hasTableData() || isUpdating || !hasPendingTableChanges()">
+      <mat-spinner *ngIf="isUpdating" class="btn-spinner" [diameter]="16" [strokeWidth]="2"></mat-spinner>
+      <span style="color: white;">{{ isUpdating ? uiConfig.labels.saving : uiConfig.labels.save }}</span>
+    </button>
+  </ng-container>
 </div>
 
 <!-- Main Content -->
@@ -60,32 +62,34 @@
     <!-- Right Tools: Action Buttons -->
     <div class="right-tools">
       <div class="button-group">
-        <!-- Remove Button -->
-        <button mat-stroked-button class="app-btn icon red" (click)="onRemoveClicked()"
-          [disabled]="!selectedRows.length || !hasTableData() || isDeleting" *ngIf="routeMode === 'manage'">
-          <mat-spinner *ngIf="isDeleting" class="btn-spinner" [diameter]="16" [strokeWidth]="2"></mat-spinner>
-          <img src="{{ uiConfig.icons.remove }}" alt="delete" class="btn-icon" />
-          {{ uiConfig.labels.remove }}
-        </button>
+        <ng-container *ngIf="routeMode === 'manage'">
+          <!-- Remove Button - hidden for view-only -->
+          <button mat-stroked-button class="app-btn icon red" (click)="onRemoveClicked()" *appHideForViewOnly
+            [disabled]="!selectedRows.length || !hasTableData() || isDeleting">
+            <mat-spinner *ngIf="isDeleting" class="btn-spinner" [diameter]="16" [strokeWidth]="2"></mat-spinner>
+            <img src="{{ uiConfig.icons.remove }}" alt="delete" class="btn-icon" />
+            {{ uiConfig.labels.remove }}
+          </button>
 
-        <!-- Edit Button -->
-        <button mat-stroked-button class="app-btn icon blue" (click)="onEditClicked()"
-          [disabled]="!selectedRows.length || !hasTableData()" *ngIf="routeMode === 'manage'">
-          <img src="{{ uiConfig.icons.edit }}" alt="edit" class="btn-icon" />
-          {{ uiConfig.labels.edit }}
-        </button>
+          <!-- Edit Button - hidden for view-only -->
+          <button mat-stroked-button class="app-btn icon blue" (click)="onEditClicked()" *appHideForViewOnly
+            [disabled]="!selectedRows.length || !hasTableData()">
+            <img src="{{ uiConfig.icons.edit }}" alt="edit" class="btn-icon" />
+            {{ uiConfig.labels.edit }}
+          </button>
+        </ng-container>
 
-        <!-- Download Template Button -->
-        <button mat-stroked-button class="app-btn secondary" (click)="onDownloadTemplate()"
-          *ngIf="routeMode !== 'manage'">
-          {{ uiConfig.labels.downloadSample }}
-        </button>
+        <ng-container *ngIf="routeMode !== 'manage'">
+          <!-- Download Template Button -->
+          <button mat-stroked-button class="app-btn secondary" (click)="onDownloadTemplate()">
+            {{ uiConfig.labels.downloadSample }}
+          </button>
 
-        <!-- Upload File Button -->
-        <button type="button" (click)="openUploadPopup()" mat-button class="app-btn primary"
-          *ngIf="routeMode !== 'manage'">
-          {{ uploadButtonText }}
-        </button>
+          <!-- Upload File Button - hidden for view-only -->
+          <button type="button" (click)="openUploadPopup()" mat-button class="app-btn primary" *appHideForViewOnly>
+            {{ uploadButtonText }}
+          </button>
+        </ng-container>
       </div>
     </div>
   </div>

--- a/project/ws/app/src/lib/routes/frac/pages/competency/competency-upload/competency-upload.component.html
+++ b/project/ws/app/src/lib/routes/frac/pages/competency/competency-upload/competency-upload.component.html
@@ -4,12 +4,14 @@
     <span>Back</span>
   </button>
 
-  <!-- Save Button - Disabled when no data -->
-  <button class="save-btn" (click)="onSaveClicked()" *ngIf="routeMode === 'manage'"
-    [disabled]="!isEditing || !hasTableData() || isUpdating || !hasPendingTableChanges()">
-    <mat-spinner *ngIf="isUpdating" class="btn-spinner" [diameter]="16" [strokeWidth]="2"></mat-spinner>
-    <span style="color: white;">{{ isUpdating ? uiConfig.labels.saving : uiConfig.labels.save }}</span>
-  </button>
+  <!-- Save Button - Disabled when no data; hidden for view-only -->
+  <ng-container *ngIf="routeMode === 'manage'">
+    <button class="save-btn" (click)="onSaveClicked()" *appHideForViewOnly
+      [disabled]="!isEditing || !hasTableData() || isUpdating || !hasPendingTableChanges()">
+      <mat-spinner *ngIf="isUpdating" class="btn-spinner" [diameter]="16" [strokeWidth]="2"></mat-spinner>
+      <span style="color: white;">{{ isUpdating ? uiConfig.labels.saving : uiConfig.labels.save }}</span>
+    </button>
+  </ng-container>
 </div>
 
 
@@ -56,30 +58,32 @@
     <div class="right-tools">
 
       <div class="button-group">
-        <!-- Remove Button (Red Outline + Icon) - Disabled when no data -->
-        <button mat-stroked-button class="app-btn icon red" (click)="onRemoveClicked()"
-          [disabled]="!selectedRows.length || !hasTableData() || isDeleting" *ngIf="routeMode === 'manage'">
-          <mat-spinner *ngIf="isDeleting" class="btn-spinner" [diameter]="16" [strokeWidth]="2"></mat-spinner>
-          <img src="{{ uiConfig.icons.remove }}" alt="delete" class="btn-icon" />
-          {{ uiConfig.labels.remove }}
-        </button>
-        <!-- Edit Button (Blue Outline + Icon) - Disabled when no data -->
-        <button mat-stroked-button class="app-btn icon blue" (click)="onEditClicked()"
-          [disabled]="!selectedRows.length || !hasTableData()" *ngIf="routeMode === 'manage'">
-          <img src="{{ uiConfig.icons.edit }}" alt="edit" class="btn-icon" />
-          {{ uiConfig.labels.edit }}
-        </button>
+        <ng-container *ngIf="routeMode === 'manage'">
+          <!-- Remove Button (Red Outline + Icon) - Disabled when no data; hidden for view-only -->
+          <button mat-stroked-button class="app-btn icon red" (click)="onRemoveClicked()" *appHideForViewOnly
+            [disabled]="!selectedRows.length || !hasTableData() || isDeleting">
+            <mat-spinner *ngIf="isDeleting" class="btn-spinner" [diameter]="16" [strokeWidth]="2"></mat-spinner>
+            <img src="{{ uiConfig.icons.remove }}" alt="delete" class="btn-icon" />
+            {{ uiConfig.labels.remove }}
+          </button>
+          <!-- Edit Button (Blue Outline + Icon) - Disabled when no data; hidden for view-only -->
+          <button mat-stroked-button class="app-btn icon blue" (click)="onEditClicked()" *appHideForViewOnly
+            [disabled]="!selectedRows.length || !hasTableData()">
+            <img src="{{ uiConfig.icons.edit }}" alt="edit" class="btn-icon" />
+            {{ uiConfig.labels.edit }}
+          </button>
+        </ng-container>
 
-        <!-- Secondary Button -->
-        <button mat-stroked-button class="app-btn secondary" (click)="onDownloadTemplate()"
-          *ngIf="routeMode !== 'manage'">
-          {{ uiConfig.labels.downloadSample }}
-        </button>
-        <!-- Primary Button -->
-        <button type="button" (click)="openUploadPopup()" mat-button class="app-btn primary"
-          *ngIf="routeMode !== 'manage'">
-          {{ uploadButtonText }}
-        </button>
+        <ng-container *ngIf="routeMode !== 'manage'">
+          <!-- Secondary Button -->
+          <button mat-stroked-button class="app-btn secondary" (click)="onDownloadTemplate()">
+            {{ uiConfig.labels.downloadSample }}
+          </button>
+          <!-- Primary (Upload) Button - hidden for view-only -->
+          <button type="button" (click)="openUploadPopup()" mat-button class="app-btn primary" *appHideForViewOnly>
+            {{ uploadButtonText }}
+          </button>
+        </ng-container>
       </div>
     </div>
   </div>

--- a/project/ws/app/src/lib/routes/frac/pages/frac-dashboard/frac-dashboard.component.html
+++ b/project/ws/app/src/lib/routes/frac/pages/frac-dashboard/frac-dashboard.component.html
@@ -21,11 +21,14 @@
 
       <!-- Card Actions -->
       <div class="card-actions">
-        <button type="button" (click)="onBtnClick(action.redirectLink)" class="action-btn"
-          *ngFor="let action of card.actions">
-          <img class="action-icon" [src]="getIconUrl(action.icon)" [alt]="action.label" />
-          <span class="action-label">{{ action.label }}</span>
-        </button>
+        <ng-container *ngFor="let action of card.actions">
+          <!-- Upload (create) actions are hidden for FRAC view-only users; Manage/Map navigation stays. -->
+          <button type="button" (click)="onBtnClick(action.redirectLink)" class="action-btn"
+            *appHideForViewOnly="action.icon === 'upload'">
+            <img class="action-icon" [src]="getIconUrl(action.icon)" [alt]="action.label" />
+            <span class="action-label">{{ action.label }}</span>
+          </button>
+        </ng-container>
       </div>
     </mat-card>
   </section>

--- a/project/ws/app/src/lib/routes/frac/pages/position/position-upload/position-upload.component.html
+++ b/project/ws/app/src/lib/routes/frac/pages/position/position-upload/position-upload.component.html
@@ -5,12 +5,14 @@
     <span>Back</span>
   </button>
 
-  <!-- Save shown only in table-manage mode -->
-  <button class="save-btn" (click)="onSaveClicked()" *ngIf="routeMode === 'manage'"
-    [disabled]="!isEditing || !hasTableData() || isUpdating || !hasPendingTableChanges()">
-    <mat-spinner *ngIf="isUpdating" class="btn-spinner" [diameter]="16" [strokeWidth]="2"></mat-spinner>
-    <span>{{ isUpdating ? uiConfig.labels.saving : uiConfig.labels.save }}</span>
-  </button>
+  <!-- Save shown only in table-manage mode; hidden for FRAC view-only users -->
+  <ng-container *ngIf="routeMode === 'manage'">
+    <button class="save-btn" (click)="onSaveClicked()" *appHideForViewOnly
+      [disabled]="!isEditing || !hasTableData() || isUpdating || !hasPendingTableChanges()">
+      <mat-spinner *ngIf="isUpdating" class="btn-spinner" [diameter]="16" [strokeWidth]="2"></mat-spinner>
+      <span>{{ isUpdating ? uiConfig.labels.saving : uiConfig.labels.save }}</span>
+    </button>
+  </ng-container>
 </div>
 
 <!-- Main Content -->
@@ -33,7 +35,8 @@
           <button mat-stroked-button class="app-btn secondary" (click)="onDownloadTemplate()">
             {{ uiConfig.labels.downloadSample }}
           </button>
-          <button type="button" (click)="openUploadPopup()" mat-button class="app-btn primary">
+          <button type="button" (click)="openUploadPopup()" mat-button class="app-btn primary"
+            *appHideForViewOnly>
             {{ uploadButtonText }}
           </button>
         </div>
@@ -103,7 +106,8 @@
         </div>
 
         <div class="manage-header-buttons">
-          <button type="button" class="upload-position-btn" (click)="goToUploadMode()">
+          <button type="button" class="upload-position-btn" (click)="goToUploadMode()"
+            *appHideForViewOnly>
             <img [src]="uiConfig.icons.upload" alt="upload" class="action-btn-icon" />
             {{ uiConfig.labels.uploadPositionBtn }}
           </button>
@@ -195,7 +199,8 @@
               <mat-icon class="card-action-icon">visibility</mat-icon>
               View
             </button>
-            <button type="button" class="card-action-btn card-action-edit" (click)="onViewEdit(pos)">
+            <button type="button" class="card-action-btn card-action-edit" (click)="onViewEdit(pos)"
+              *appHideForViewOnly>
               <mat-icon class="card-action-icon">edit</mat-icon>
               Edit
             </button>
@@ -248,12 +253,14 @@
       <div class="right-tools">
         <div class="button-group">
           <button mat-stroked-button class="app-btn icon red" (click)="onRemoveClicked()"
+            *appHideForViewOnly
             [disabled]="!selectedRows.length || !hasTableData() || isDeleting">
             <mat-spinner *ngIf="isDeleting" class="btn-spinner" [diameter]="16" [strokeWidth]="2"></mat-spinner>
             <img [src]="uiConfig.icons.remove" alt="delete" class="btn-icon" />
             {{ uiConfig.labels.remove }}
           </button>
           <button mat-stroked-button class="app-btn icon blue" (click)="onEditClicked()"
+            *appHideForViewOnly
             [disabled]="!selectedRows.length || !hasTableData()">
             <img [src]="uiConfig.icons.edit" alt="edit" class="btn-icon" />
             {{ uiConfig.labels.edit }}

--- a/project/ws/app/src/lib/routes/frac/pages/role/role-upload/role-upload.component.html
+++ b/project/ws/app/src/lib/routes/frac/pages/role/role-upload/role-upload.component.html
@@ -5,11 +5,13 @@
     <span>Back</span>
   </button>
 
-  <button class="save-btn" (click)="onSaveClicked()" *ngIf="routeMode === 'manage'"
-    [disabled]="!isEditing || !hasTableData() || isUpdating || !hasPendingTableChanges()">
-    <mat-spinner *ngIf="isUpdating" class="btn-spinner" [diameter]="16" [strokeWidth]="2"></mat-spinner>
-    <span style="color: white;">{{ isUpdating ? uiConfig.labels.saving : uiConfig.labels.save }}</span>
-  </button>
+  <ng-container *ngIf="routeMode === 'manage'">
+    <button class="save-btn" (click)="onSaveClicked()" *appHideForViewOnly
+      [disabled]="!isEditing || !hasTableData() || isUpdating || !hasPendingTableChanges()">
+      <mat-spinner *ngIf="isUpdating" class="btn-spinner" [diameter]="16" [strokeWidth]="2"></mat-spinner>
+      <span style="color: white;">{{ isUpdating ? uiConfig.labels.saving : uiConfig.labels.save }}</span>
+    </button>
+  </ng-container>
 </div>
 
 <!-- Main Content -->
@@ -60,32 +62,34 @@
     <!-- Right Tools: Action Buttons -->
     <div class="right-tools">
       <div class="button-group">
-        <!-- Remove Button -->
-        <button mat-stroked-button class="app-btn icon red" (click)="onRemoveClicked()"
-          [disabled]="!selectedRows.length || !hasTableData() || isDeleting" *ngIf="routeMode === 'manage'">
-          <mat-spinner *ngIf="isDeleting" class="btn-spinner" [diameter]="16" [strokeWidth]="2"></mat-spinner>
-          <img src="{{ uiConfig.icons.remove }}" alt="delete" class="btn-icon" />
-          {{ uiConfig.labels.remove }}
-        </button>
+        <ng-container *ngIf="routeMode === 'manage'">
+          <!-- Remove Button - hidden for view-only -->
+          <button mat-stroked-button class="app-btn icon red" (click)="onRemoveClicked()" *appHideForViewOnly
+            [disabled]="!selectedRows.length || !hasTableData() || isDeleting">
+            <mat-spinner *ngIf="isDeleting" class="btn-spinner" [diameter]="16" [strokeWidth]="2"></mat-spinner>
+            <img src="{{ uiConfig.icons.remove }}" alt="delete" class="btn-icon" />
+            {{ uiConfig.labels.remove }}
+          </button>
 
-        <!-- Edit Button -->
-        <button mat-stroked-button class="app-btn icon blue" (click)="onEditClicked()"
-          [disabled]="!selectedRows.length || !hasTableData()" *ngIf="routeMode === 'manage'">
-          <img src="{{ uiConfig.icons.edit }}" alt="edit" class="btn-icon" />
-          {{ uiConfig.labels.edit }}
-        </button>
+          <!-- Edit Button - hidden for view-only -->
+          <button mat-stroked-button class="app-btn icon blue" (click)="onEditClicked()" *appHideForViewOnly
+            [disabled]="!selectedRows.length || !hasTableData()">
+            <img src="{{ uiConfig.icons.edit }}" alt="edit" class="btn-icon" />
+            {{ uiConfig.labels.edit }}
+          </button>
+        </ng-container>
 
-        <!-- Download Template Button -->
-        <button mat-stroked-button class="app-btn secondary" (click)="onDownloadTemplate()"
-          *ngIf="routeMode !== 'manage'">
-          {{ uiConfig.labels.downloadSample }}
-        </button>
+        <ng-container *ngIf="routeMode !== 'manage'">
+          <!-- Download Template Button -->
+          <button mat-stroked-button class="app-btn secondary" (click)="onDownloadTemplate()">
+            {{ uiConfig.labels.downloadSample }}
+          </button>
 
-        <!-- Upload File Button -->
-        <button type="button" (click)="openUploadPopup()" mat-button class="app-btn primary"
-          *ngIf="routeMode !== 'manage'">
-          {{ uploadButtonText }}
-        </button>
+          <!-- Upload File Button - hidden for view-only -->
+          <button type="button" (click)="openUploadPopup()" mat-button class="app-btn primary" *appHideForViewOnly>
+            {{ uploadButtonText }}
+          </button>
+        </ng-container>
       </div>
     </div>
   </div>

--- a/project/ws/app/src/lib/routes/playlist/PLAYLIST_USER_GUIDE.md
+++ b/project/ws/app/src/lib/routes/playlist/PLAYLIST_USER_GUIDE.md
@@ -1,0 +1,143 @@
+# Playlist — User Journey Guide
+
+The **Playlist** feature lets an admin decide what learners see on their app home screen — which **Courses**, which **Competencies**, and how the **Search** behaves — for a chosen organisation, role and language.
+
+This guide walks through every screen end-to-end: **what** the screen is, **why** it exists, and **how** to use it.
+
+---
+
+## The Big Picture
+
+You always do three things, in order:
+
+1. **Pick your audience** — choose Org, Position/Role and Language (the "scope").
+2. **Open the dashboard** — three cards: Manage Course, Manage Competency, Manage Search.
+3. **Configure & save** — pick items, arrange their order, and save. Learners instantly see the change.
+
+```
+Filters  ──►  Dashboard  ──►  ┌─ Manage Course      (Select → Order → Save)
+                              ├─ Manage Competency  (Select → Assign courses to levels → Save)
+                              └─ Manage Search      (Edit query → Save)
+```
+
+---
+
+## Screen 1 — Select Position & Language (Filters)
+
+**Route:** `/app/home/playlist/filters`
+
+- **What:** A form with Organisation, Position, District, Block and Language dropdowns.
+- **Why:** Everything you set up later applies only to this audience. This is the "for whom" step.
+- **How:** Pick Organisation + Position + Language (required). District/Block are optional. Click **Continue**.
+
+> On Continue, the system quietly loads any existing Course / Competency / Search playlists for this scope, so the next screen can show counts and pre-tick already-saved items.
+
+---
+
+## Screen 2 — Admin Portal Dashboard (Summary)
+
+**Route:** `/app/home/playlist/summary`
+
+- **What:** The home dashboard. A scope bar at the top (Org, Position, Language + **Change** button) and three cards.
+- **Why:** Single place to see what's already configured and jump into editing.
+- **How:** Each card shows a count + "last updated", and has two buttons:
+  - **Manage / Create** → edit that playlist.
+  - **View** → open a read-only popup of what's currently saved.
+
+| Card | Manage button takes you to | View button shows |
+|------|---------------------------|-------------------|
+| **Manage Course** | Select Courses (Screen 3) | Course Playlist View popup |
+| **Manage Competency** | Select Competencies (Screen 5) | Competency Playlist View popup |
+| **Manage Search** | Manage Search editor (Screen 7) | Search query popup |
+
+> Use **Change** in the scope bar to go back to Screen 1 and switch audience.
+
+---
+
+## Course Flow
+
+### Screen 3 — Select Courses
+
+**Route:** `/app/playlist/select-courses`
+
+- **What:** A searchable table of all available courses with checkboxes.
+- **Why:** Choose which courses appear on the learner's home screen.
+- **How:** Search by identifier / name / source, tick the courses you want, click **Next**. (Already-saved courses come pre-ticked and float to the top.)
+
+### Screen 4 — Manage Courses Order
+
+**Route:** `/app/playlist/manage-course-order`
+
+- **What:** Your chosen courses in a drag-handle list, numbered 1, 2, 3…
+- **Why:** The order here is the exact order learners see. Top = shown first.
+- **How:** Drag rows to reorder, then click **Save**. A success popup confirms, and you return to the dashboard.
+
+> If your selected roles differ from what was saved before, a **Role Confirmation** popup appears first — confirm to apply the change to those roles too.
+
+---
+
+## Competency Flow
+
+### Screen 5 — Select Competencies
+
+**Route:** `/app/playlist/select-competencies`
+
+- **What:** A table of competencies, each with a code (ME3, ME4…) and name, with checkboxes.
+- **Why:** Choose which competencies learners see and practice on.
+- **How:** Search by name/code, tick the competencies you want, click **Assign courses**.
+
+### Screen 6 — Manage Competency Order & Assign Courses
+
+**Route:** `/app/playlist/manage-competency-order`
+
+- **What:** Two panels — left: your competencies (draggable, numbered); right: the selected competency's **Levels 1–5**, each with a course dropdown.
+- **Why:** Each competency level needs a course mapped to it, and the competency order controls display order.
+- **How:**
+  1. Click a competency on the left.
+  2. For each Level 1–5, pick a course from the dropdown.
+  3. A green tick appears once all levels are filled; move to the next competency.
+  4. Drag to reorder competencies, then click **Save**.
+
+> A competency is "complete" only when all 5 levels have a course. The same Role Confirmation popup may appear on save.
+
+---
+
+## Search Flow
+
+### Screen 7 — Manage Search
+
+**Route:** `/app/playlist/manage-search`
+
+- **What:** A JSON editor holding the search query that decides which courses surface dynamically.
+- **Why:** Advanced control — instead of hand-picking, define rules (language, source, category, limits).
+- **How:** Edit the JSON, use **Format JSON** to tidy it, then **Save**. Invalid JSON blocks saving.
+
+---
+
+## View Popups (Read-Only)
+
+Opened by the **View** buttons on the dashboard — these never change anything, they just show what's live.
+
+- **Course Playlist View:** Org ID, Org Name, Playlist ID, Language, Role, and the ordered list of courses (ID, name, source).
+- **Competency Playlist View:** Same header, plus each competency expandable to show its Levels 1–5 and the course mapped to each.
+
+---
+
+## Quick End-to-End: Create a Course Playlist
+
+1. **Filters** → pick Org, Position, Language → **Continue**.
+2. **Dashboard** → on Manage Course card, click **Create**.
+3. **Select Courses** → tick courses → **Next**.
+4. **Manage Courses Order** → drag to arrange → **Save**.
+5. Success popup → back on dashboard, the count updates. Done — learners see it immediately.
+
+> Competency and Search follow the same pattern: pick → arrange/assign → Save.
+
+---
+
+## Good to Know
+
+- **Nothing is lost going Back** — selections are held in memory until you save or change scope.
+- **Editing vs creating** is automatic — if a playlist already exists for the scope, your saved items come pre-selected.
+- **Saving merges roles** — it won't silently drop courses already assigned to other roles.
+- **After every save**, fresh data is reloaded so the dashboard counts stay accurate.

--- a/project/ws/app/src/lib/routes/playlist/pages/manage-competency-order/manage-competency-order.component.html
+++ b/project/ws/app/src/lib/routes/playlist/pages/manage-competency-order/manage-competency-order.component.html
@@ -6,7 +6,8 @@
             <span>Back</span>
         </button>
         <div class="header-spacer"></div>
-        <button class="save-btn-top" [disabled]="!allCompetenciesComplete() || saving()" (click)="onSave()">
+        <button class="save-btn-top" [disabled]="!allCompetenciesComplete() || saving()" (click)="onSave()"
+            *appHideForViewOnly>
             <span *ngIf="!saving()">Save</span>
             <span *ngIf="saving()">Saving...</span>
         </button>
@@ -20,7 +21,7 @@
     <div class="action-row">
         <button class="assign-btn"
             [disabled]="!selectedCompetency() || !isCurrentCompetencyComplete() || allCompetenciesComplete()"
-            (click)="onAssignCourses()">
+            (click)="onAssignCourses()" *appHideForViewOnly>
             Assign courses
         </button>
     </div>
@@ -44,7 +45,8 @@
             </div>
 
             <!-- Competency List -->
-            <div cdkDropList class="competencies-list" (cdkDropListDropped)="onDrop($event)">
+            <div cdkDropList class="competencies-list" (cdkDropListDropped)="onDrop($event)"
+                [cdkDropListDisabled]="isViewOnly">
                 <div *ngFor="let competency of filteredCompetencies()" cdkDrag class="competency-item"
                     [class.selected]="selectedCompetency() === competency"
                     [class.complete]="isCompetencyComplete(competency)" (click)="onSelectCompetency(competency)">
@@ -104,7 +106,7 @@
                             <!-- Course Dropdown -->
                             <mat-form-field *ngIf="!loadingCourses()" appearance="outline" class="dropdown-field">
                                 <mat-select [(ngModel)]="level.courseId" placeholder="Search or select Course"
-                                    (selectionChange)="onCourseSelect(level, $event.value)">
+                                    [disabled]="isViewOnly" (selectionChange)="onCourseSelect(level, $event.value)">
                                     <mat-option
                                         *ngIf="!loadingCourses() && getCoursesForLevel(level.level).length === 0"
                                         disabled>No courses

--- a/project/ws/app/src/lib/routes/playlist/pages/manage-competency-order/manage-competency-order.component.ts
+++ b/project/ws/app/src/lib/routes/playlist/pages/manage-competency-order/manage-competency-order.component.ts
@@ -28,6 +28,8 @@ import {
     CompetencyPayloadItem,
 } from '../../utils/competency-payload.utils'
 import { log } from '../../utils/playlist-logger.utils'
+import { HideForViewOnlyDirective } from '../../../../shared/directives/hide-for-view-only.directive'
+import { FeatureAccessService, FEATURE_KEY } from '../../../../shared/access/feature-access'
 
 /**
  * Component for managing competency playlists.
@@ -44,7 +46,7 @@ import { log } from '../../utils/playlist-logger.utils'
     styleUrls: ['./manage-competency-order.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [CommonModule, FormsModule, DragDropModule, MatDialogModule, MatButtonModule, MatFormFieldModule, MatSelectModule, MatOptionModule, MatIconModule, MatInputModule],
+    imports: [CommonModule, FormsModule, DragDropModule, MatDialogModule, MatButtonModule, MatFormFieldModule, MatSelectModule, MatOptionModule, MatIconModule, MatInputModule, HideForViewOnlyDirective],
 })
 export class ManageCompetencyOrderComponent implements OnInit {
     readonly competencies = signal<SelectableCompetency[]>([])
@@ -74,6 +76,13 @@ export class ManageCompetencyOrderComponent implements OnInit {
     private readonly state = inject(PlaylistStateService)
     private readonly playlistApi = inject(PlaylistApiService)
     private readonly courseApi = inject(CourseApiService)
+    private readonly featureAccess = inject(FeatureAccessService)
+    private readonly featureKey = inject(FEATURE_KEY, { optional: true })
+
+    /** Read-only mode for view-only users — disables reordering and course dropdowns. */
+    get isViewOnly(): boolean {
+        return this.featureAccess.isViewOnly(this.featureKey)
+    }
 
     /**
      * Component initialization.

--- a/project/ws/app/src/lib/routes/playlist/pages/manage-course-order/manage-course-order.component.html
+++ b/project/ws/app/src/lib/routes/playlist/pages/manage-course-order/manage-course-order.component.html
@@ -5,7 +5,8 @@
             <mat-icon>arrow_back</mat-icon>
             <span>Back</span>
         </button>
-        <button mat-raised-button class="save-btn-top" [disabled]="!isSaveEnabled()" (click)="onSave()">
+        <button mat-raised-button class="save-btn-top" [disabled]="!isSaveEnabled()" (click)="onSave()"
+            *appHideForViewOnly>
             <span *ngIf="!saving()">Save</span>
             <span *ngIf="saving()">Saving...</span>
         </button>
@@ -33,7 +34,8 @@
         </div>
 
         <!-- Course List -->
-        <div cdkDropList class="courses-list" (cdkDropListDropped)="onDrop($event)">
+        <div cdkDropList class="courses-list" (cdkDropListDropped)="onDrop($event)"
+            [cdkDropListDisabled]="isViewOnly">
             <div *ngFor="let course of filteredCourses()" cdkDrag class="course-item">
 
                 <!-- Drag Handle -->

--- a/project/ws/app/src/lib/routes/playlist/pages/manage-course-order/manage-course-order.component.ts
+++ b/project/ws/app/src/lib/routes/playlist/pages/manage-course-order/manage-course-order.component.ts
@@ -17,6 +17,8 @@ import { RoleConfirmDialogComponent, RoleConfirmDialogData } from '../../compone
 import { ErrorDialogComponent, ErrorDialogData } from '../../components/error-dialog/error-dialog.component'
 import { PLAYLIST_ROUTES, PLAYLIST_UI } from '../../constants/playlist.constants'
 import { log } from '../../utils/playlist-logger.utils'
+import { HideForViewOnlyDirective } from '../../../../shared/directives/hide-for-view-only.directive'
+import { FeatureAccessService, FEATURE_KEY } from '../../../../shared/access/feature-access'
 
 /**
  * Component for finalizing the order of courses within a playlist.
@@ -28,7 +30,7 @@ import { log } from '../../utils/playlist-logger.utils'
     styleUrls: ['./manage-course-order.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [CommonModule, DragDropModule, MatDialogModule, MatButtonModule, MatFormFieldModule, MatInputModule, MatIconModule],
+    imports: [CommonModule, DragDropModule, MatDialogModule, MatButtonModule, MatFormFieldModule, MatInputModule, MatIconModule, HideForViewOnlyDirective],
 })
 export class ManageCourseOrderComponent implements OnInit {
     readonly orderedCourses = signal<SelectableCourse[]>([])
@@ -43,6 +45,13 @@ export class ManageCourseOrderComponent implements OnInit {
     private readonly state = inject(PlaylistStateService)
     private readonly playlistApi = inject(PlaylistApiService)
     private readonly dialog = inject(MatDialog)
+    private readonly featureAccess = inject(FeatureAccessService)
+    private readonly featureKey = inject(FEATURE_KEY, { optional: true })
+
+    /** Read-only mode for view-only users — disables reordering. */
+    get isViewOnly(): boolean {
+        return this.featureAccess.isViewOnly(this.featureKey)
+    }
 
     ngOnInit(): void {
         this.loadSelectedCourses()

--- a/project/ws/app/src/lib/routes/playlist/pages/manage-search/manage-search.component.html
+++ b/project/ws/app/src/lib/routes/playlist/pages/manage-search/manage-search.component.html
@@ -6,7 +6,8 @@
             <span>Back</span>
         </button>
         <div class="header-spacer"></div>
-        <button class="next-btn" type="button" [disabled]="saving() || !!validationError()" (click)="onSave()">
+        <button class="next-btn" type="button" [disabled]="saving() || !!validationError()" (click)="onSave()"
+            *appHideForViewOnly>
             {{ saving() ? 'Saving...' : 'Save' }}
         </button>
     </div>
@@ -24,7 +25,7 @@
                 <span>Search Playlist JSON</span>
             </div>
 
-            <button class="secondary-btn" type="button" (click)="onFormatJson()">
+            <button class="secondary-btn" type="button" (click)="onFormatJson()" *appHideForViewOnly>
                 <mat-icon>format_align_left</mat-icon>
                 Format
             </button>

--- a/project/ws/app/src/lib/routes/playlist/pages/manage-search/manage-search.component.ts
+++ b/project/ws/app/src/lib/routes/playlist/pages/manage-search/manage-search.component.ts
@@ -28,6 +28,8 @@ import { log } from '../../utils/playlist-logger.utils'
 import 'brace/ext/language_tools'
 import 'brace/mode/json'
 import 'brace/theme/chrome'
+import { HideForViewOnlyDirective } from '../../../../shared/directives/hide-for-view-only.directive'
+import { FeatureAccessService, FEATURE_KEY } from '../../../../shared/access/feature-access'
 
 @Component({
     selector: 'app-manage-search',
@@ -35,7 +37,7 @@ import 'brace/theme/chrome'
     styleUrls: ['./manage-search.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [CommonModule, MatButtonModule, MatDialogModule, MatIconModule],
+    imports: [CommonModule, MatButtonModule, MatDialogModule, MatIconModule, HideForViewOnlyDirective],
 })
 export class ManageSearchComponent implements OnInit, AfterViewInit, OnDestroy {
     @ViewChild('jsonEditor', { static: false }) private jsonEditorRef?: ElementRef<HTMLElement>
@@ -49,8 +51,15 @@ export class ManageSearchComponent implements OnInit, AfterViewInit, OnDestroy {
     private readonly dialog = inject(MatDialog)
     private readonly playlistApi = inject(PlaylistApiService)
     private readonly state = inject(PlaylistStateService)
+    private readonly featureAccess = inject(FeatureAccessService)
+    private readonly featureKey = inject(FEATURE_KEY, { optional: true })
     private editor?: any
     private editorChangeHandler?: () => void
+
+    /** Read-only mode for view-only users — makes the JSON editor non-editable. */
+    get isViewOnly(): boolean {
+        return this.featureAccess.isViewOnly(this.featureKey)
+    }
 
     ngOnInit(): void {
         const filters = this.state.getFilters()
@@ -183,6 +192,8 @@ export class ManageSearchComponent implements OnInit, AfterViewInit, OnDestroy {
             useSoftTabs: true,
         })
         this.editor.$blockScrolling = Infinity
+        // View-only users can read the query but not edit it.
+        this.editor.setReadOnly(this.isViewOnly)
         this.editor.setValue(this.jsonText(), -1)
 
         this.editorChangeHandler = () => {

--- a/project/ws/app/src/lib/routes/playlist/pages/select-competencies/select-competencies.component.html
+++ b/project/ws/app/src/lib/routes/playlist/pages/select-competencies/select-competencies.component.html
@@ -58,7 +58,8 @@
                         <td class="checkbox-col">
                             <label class="custom-checkbox">
                                 <input type="checkbox" (click)="$event.stopPropagation()"
-                                    (change)="onSelectionChange(row, $event)" [checked]="selection.isSelected(row)">
+                                    (change)="onSelectionChange(row, $event)" [checked]="selection.isSelected(row)"
+                                    appDisableForViewOnly>
                                 <span class="checkmark"></span>
                             </label>
                         </td>

--- a/project/ws/app/src/lib/routes/playlist/pages/select-competencies/select-competencies.component.ts
+++ b/project/ws/app/src/lib/routes/playlist/pages/select-competencies/select-competencies.component.ts
@@ -11,6 +11,7 @@ import { getLevelNumbers } from '../../config/competency.config'
 import { PLAYLIST_ROUTES, PLAYLIST_UI } from '../../constants/playlist.constants'
 import { log } from '../../utils/playlist-logger.utils'
 import { RawCompetencyEntity, RawCompetencyLevel } from '../../utils/competency-transformer'
+import { DisableForViewOnlyDirective } from '../../../../shared/directives/disable-for-view-only.directive'
 
 /**
  * Component to handle competency selection.
@@ -22,7 +23,7 @@ import { RawCompetencyEntity, RawCompetencyLevel } from '../../utils/competency-
     styleUrls: ['./select-competencies.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [CommonModule, MatIconModule],
+    imports: [CommonModule, MatIconModule, DisableForViewOnlyDirective],
 })
 export class SelectCompetenciesComponent implements OnInit {
     selection = new SelectionModel<SelectableCompetency>(true, [])

--- a/project/ws/app/src/lib/routes/playlist/pages/select-courses/select-courses.component.html
+++ b/project/ws/app/src/lib/routes/playlist/pages/select-courses/select-courses.component.html
@@ -68,7 +68,8 @@
                         <td class="checkbox-col">
                             <label class="custom-checkbox">
                                 <input type="checkbox" (click)="$event.stopPropagation()"
-                                    (change)="onSelectionChange(row, $event)" [checked]="selection.isSelected(row)">
+                                    (change)="onSelectionChange(row, $event)" [checked]="selection.isSelected(row)"
+                                    appDisableForViewOnly>
                                 <span class="checkmark"></span>
                             </label>
                         </td>

--- a/project/ws/app/src/lib/routes/playlist/pages/select-courses/select-courses.component.ts
+++ b/project/ws/app/src/lib/routes/playlist/pages/select-courses/select-courses.component.ts
@@ -8,6 +8,7 @@ import { PlaylistStateService } from '../../services/playlist-state.service'
 import { Course, SelectableCourse } from '../../models/course.model'
 import { PLAYLIST_ROUTES, PLAYLIST_UI } from '../../constants/playlist.constants'
 import { log } from '../../utils/playlist-logger.utils'
+import { DisableForViewOnlyDirective } from '../../../../shared/directives/disable-for-view-only.directive'
 
 @Component({
     selector: 'app-select-courses',
@@ -15,7 +16,7 @@ import { log } from '../../utils/playlist-logger.utils'
     styleUrls: ['./select-courses.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [CommonModule, MatIconModule],
+    imports: [CommonModule, MatIconModule, DisableForViewOnlyDirective],
 })
 export class SelectCoursesComponent implements OnInit {
     selection = new SelectionModel<SelectableCourse>(true, [])

--- a/project/ws/app/src/lib/routes/playlist/playlist.routes.ts
+++ b/project/ws/app/src/lib/routes/playlist/playlist.routes.ts
@@ -6,6 +6,13 @@ import { ManageCourseOrderComponent } from './pages/manage-course-order/manage-c
 import { SelectCompetenciesComponent } from './pages/select-competencies/select-competencies.component'
 import { ManageCompetencyOrderComponent } from './pages/manage-competency-order/manage-competency-order.component'
 import { ManageSearchComponent } from './pages/manage-search/manage-search.component'
+import { FEATURE_KEY } from '../../shared/access/feature-access'
+
+/**
+ * Tells view-only directives in these standalone components that they render
+ * inside the Playlist feature. Inherited by all components under each route.
+ */
+const PLAYLIST_FEATURE_PROVIDERS = [{ provide: FEATURE_KEY, useValue: 'playlist' }]
 
 /**
  * Routes for /app/home/playlist/ (with sidebar)
@@ -19,10 +26,12 @@ export const HOME_PLAYLIST_ROUTES: Routes = [
     {
         path: 'filters',
         component: PlaylistFiltersComponent,
+        providers: PLAYLIST_FEATURE_PROVIDERS,
     },
     {
         path: 'summary',
         component: PlaylistSummaryComponent,
+        providers: PLAYLIST_FEATURE_PROVIDERS,
     },
 ]
 
@@ -33,21 +42,26 @@ export const STANDALONE_PLAYLIST_ROUTES: Routes = [
     {
         path: 'select-courses',
         component: SelectCoursesComponent,
+        providers: PLAYLIST_FEATURE_PROVIDERS,
     },
     {
         path: 'manage-course-order',
         component: ManageCourseOrderComponent,
+        providers: PLAYLIST_FEATURE_PROVIDERS,
     },
     {
         path: 'select-competencies',
         component: SelectCompetenciesComponent,
+        providers: PLAYLIST_FEATURE_PROVIDERS,
     },
     {
         path: 'manage-competency-order',
         component: ManageCompetencyOrderComponent,
+        providers: PLAYLIST_FEATURE_PROVIDERS,
     },
     {
         path: 'manage-search',
         component: ManageSearchComponent,
+        providers: PLAYLIST_FEATURE_PROVIDERS,
     },
 ]

--- a/project/ws/app/src/lib/shared/access/VIEW_ONLY_ACCESS.md
+++ b/project/ws/app/src/lib/shared/access/VIEW_ONLY_ACCESS.md
@@ -1,0 +1,71 @@
+# Role-Based View-Only Access
+
+Some roles can **only view** a feature. They can browse and navigate everything, but every way to change data is removed or locked: mutating buttons are hidden, and input controls (checkboxes, dropdowns, drag-reorder, editors) are disabled. Everyone else is unaffected.
+
+## Roles
+
+| Role | FRAC feature | Playlist feature |
+|------|--------------|------------------|
+| `FRAC_ADMIN` | Full access (view + edit) | — unaffected — |
+| `FRAC_READ` | **View only** | — unaffected — |
+| `PLAYLIST_ADMIN` | — unaffected — | Full access (view + edit) |
+| `PLAYLIST_READ` | — unaffected — | **View only** |
+| any other role | unaffected | unaffected |
+
+**Rule:** a user is view-only for a feature when they have its `*_READ` role **and not** its `*_ADMIN` role. Each feature is independent — `FRAC_READ` never affects Playlist, and vice versa.
+
+## What "view only" does
+
+Navigation and data stay visible so the user can read and explore everything. Mutating buttons are **hidden**; input controls are **disabled** (shown but greyed out).
+
+### FRAC (`FRAC_READ`)
+Covers the FRAC tab + Manage Positions.
+
+| Hidden (mutations) | Disabled (inputs) | Stays visible |
+|--------------------|-------------------|---------------|
+| Upload, Save, Edit, Remove | Row-selection checkboxes (manage tables) | View, Manage (navigation), Search |
+| Add (mapping pages) | Mapping checkboxes | Download sample, Language, Back |
+| Confirm & Upload (modal) | | All data cards / tables |
+
+### Playlist (`PLAYLIST_READ`)
+View-only users can open Manage and walk through **every** screen to see lists, dropdowns and the search query — they just can't change anything.
+
+| Hidden (mutations) | Disabled (inputs) | Stays visible |
+|--------------------|-------------------|---------------|
+| Save (all screens) | Selection checkboxes | Manage / Create, View, Change |
+| Assign courses (order screen)\* | Course dropdowns | Next, Assign courses (select screen) |
+| Format (JSON) | Drag-reorder | Back, Search, Clear Search |
+| | JSON editor (read-only) | All data, lists, current order |
+
+\* The "Assign courses" button on **Manage Competency Order** is a mutation (marks courses assigned), so it's hidden; the same-named button on **Select Competencies** is navigation, so it stays.
+
+## How it works
+
+Two directives read the current feature automatically (no per-element config), plus a component flag for Angular Material controls:
+
+- `*appHideForViewOnly` — **removes** an action button for view-only users.
+- `appDisableForViewOnly` — **disables** a control but keeps it visible. Works on native inputs and `<mat-checkbox>`; only ever *adds* the disabled state, so existing `[disabled]` logic is preserved.
+- `get isViewOnly()` — components expose this (it calls `FeatureAccessService.isViewOnly()`) to bind Material controls that can't take an attribute directive cleanly: `[cdkDropListDisabled]`, `mat-select [disabled]`, and the Ace editor's `setReadOnly()`.
+
+## Where things live
+
+| What | File |
+|------|------|
+| Role config (single source of truth) | `shared/access/feature-access.ts` |
+| Hide directive (buttons) | `shared/directives/hide-for-view-only.directive.ts` |
+| Disable directive (checkboxes) | `shared/directives/disable-for-view-only.directive.ts` |
+| Role onboarding (login gate) | `src/environments/env.util.ts` |
+
+## Adding a new feature later
+
+1. Add one line to `FEATURE_ACCESS` in `feature-access.ts`:
+   ```ts
+   reports: { admin: 'reports_admin', read: 'reports_read' },
+   ```
+2. Provide its key in that feature's module/routes:
+   ```ts
+   { provide: FEATURE_KEY, useValue: 'reports' }
+   ```
+3. Add the new roles to `DEFAULT_REQUIRED_ROLES` in `env.util.ts` (and the DevOps `portalRoles` env).
+
+Nothing else changes — existing buttons need no edits.

--- a/project/ws/app/src/lib/shared/access/feature-access.ts
+++ b/project/ws/app/src/lib/shared/access/feature-access.ts
@@ -1,0 +1,83 @@
+import { Injectable, InjectionToken } from '@angular/core'
+import { ConfigurationsService } from '@sunbird-cb/utils'
+
+/**
+ * Per-feature, role-based view-only access — single source of truth.
+ *
+ * To add a feature: add one entry to FEATURE_ACCESS, then provide its key via
+ * FEATURE_KEY in that feature's module/route. Nothing else changes.
+ *
+ * Semantics (only the `*_read` role is ever restricted):
+ *   - has admin role            -> full access (view + edit/create/delete)
+ *   - has read role, not admin  -> view-only (mutating actions hidden)
+ *   - neither                   -> untouched (no feature is impacted)
+ */
+
+/** Keys of features that support view-only gating. */
+export type FeatureKey = 'frac' | 'playlist'
+
+export interface FeatureRoleSet {
+  /** Role that grants full access. */
+  admin: string
+  /** Role that grants read-only access. */
+  read: string
+}
+
+/** Map each feature to its roles. Roles are lowercase (userRoles is lowercased). */
+export const FEATURE_ACCESS: Record<FeatureKey, FeatureRoleSet> = {
+  frac: { admin: 'frac_admin', read: 'frac_read' },
+  playlist: { admin: 'playlist_admin', read: 'playlist_read' },
+}
+
+/**
+ * DI token that tells view-only directives which feature they render inside.
+ * Provided once per feature (FracModule / playlist routes).
+ */
+export const FEATURE_KEY = new InjectionToken<FeatureKey>('FEATURE_KEY')
+
+@Injectable({ providedIn: 'root' })
+export class FeatureAccessService {
+  constructor(private configSvc: ConfigurationsService) {}
+
+  /**
+   * Current user's roles, lowercased so matching is case-insensitive against the
+   * lowercase config keys (DB stores e.g. FRAC_READ; userRoles is already
+   * lowercased — this just guarantees it).
+   */
+  private roles(): Set<string> {
+    const real = this.configSvc && this.configSvc.userRoles
+    const source = real ? Array.from(real) : []
+    return new Set<string>(source.map((r) => (r || '').toLowerCase()))
+  }
+
+  /**
+   * True when the user may only view this feature (has read role, not admin).
+   * Fails open (returns false) on any unexpected error so the UI is never blocked
+   * or broken by an access check — view-only is strictly additive.
+   */
+  isViewOnly(feature: FeatureKey | null | undefined): boolean {
+    try {
+      if (!feature) {
+        return false
+      }
+      const cfg = FEATURE_ACCESS[feature]
+      if (!cfg) {
+        return false
+      }
+      const roles = this.roles()
+      return roles.has(cfg.read) && !roles.has(cfg.admin)
+    } catch {
+      return false
+    }
+  }
+
+  /** True when the user has full (edit) access to this feature. Fails open. */
+  canEdit(feature: FeatureKey): boolean {
+    try {
+      const cfg = FEATURE_ACCESS[feature]
+      return !!cfg && this.roles().has(cfg.admin)
+    } catch {
+      return false
+    }
+  }
+}

--- a/project/ws/app/src/lib/shared/directives/disable-for-view-only.directive.ts
+++ b/project/ws/app/src/lib/shared/directives/disable-for-view-only.directive.ts
@@ -1,0 +1,49 @@
+import { Directive, DoCheck, ElementRef, Inject, Optional, Self } from '@angular/core'
+import { MatCheckbox } from '@angular/material/checkbox'
+import { FeatureAccessService, FEATURE_KEY, FeatureKey } from '../access/feature-access'
+
+/**
+ * Attribute directive that disables the host control for view-only users of the
+ * current feature — keeps it visible but non-interactive. Works on native form
+ * controls (e.g. <input type="checkbox">) and on Angular Material <mat-checkbox>.
+ *
+ * Companion to `appHideForViewOnly`: use *hide* for action buttons, use *disable*
+ * for selection controls that should stay visible but greyed out (no meaning
+ * without the hidden action). Feature is resolved from DI (FEATURE_KEY); rules
+ * live in feature-access.ts.
+ *
+ * It only ever *adds* the disabled state for view-only users — it never re-enables
+ * a control — so any existing [disabled] logic (e.g. [disabled]="isReadOnly") is
+ * preserved for everyone else.
+ *
+ * Usage: <input type="checkbox" appDisableForViewOnly ...>
+ *        <mat-checkbox appDisableForViewOnly [disabled]="isReadOnly" ...>
+ */
+@Directive({
+  selector: '[appDisableForViewOnly]',
+  standalone: true,
+})
+export class DisableForViewOnlyDirective implements DoCheck {
+  constructor(
+    private el: ElementRef<HTMLElement>,
+    private access: FeatureAccessService,
+    @Optional() @Inject(FEATURE_KEY) private feature: FeatureKey | null,
+    @Optional() @Self() private matCheckbox: MatCheckbox | null,
+  ) {}
+
+  ngDoCheck(): void {
+    if (!this.access.isViewOnly(this.feature)) {
+      return
+    }
+    if (this.matCheckbox) {
+      if (!this.matCheckbox.disabled) {
+        this.matCheckbox.disabled = true
+      }
+    } else {
+      const native = this.el.nativeElement as HTMLInputElement
+      if (!native.disabled) {
+        native.disabled = true
+      }
+    }
+  }
+}

--- a/project/ws/app/src/lib/shared/directives/hide-for-view-only.directive.ts
+++ b/project/ws/app/src/lib/shared/directives/hide-for-view-only.directive.ts
@@ -1,0 +1,66 @@
+import { Directive, Inject, Input, OnInit, Optional, TemplateRef, ViewContainerRef } from '@angular/core'
+import { FeatureAccessService, FEATURE_KEY, FeatureKey } from '../access/feature-access'
+
+/**
+ * Structural directive that removes the host element for view-only users of the
+ * current feature.
+ *
+ * The feature is resolved from DI (FEATURE_KEY, provided once per feature module/
+ * route), so templates don't repeat the feature name. Role rules live in
+ * feature-access.ts. For non-restricted users the element renders unchanged, so
+ * existing editor flows are untouched.
+ *
+ * Usage:
+ *   <button *appHideForViewOnly (click)="onDelete()">Delete</button>
+ *     -> always a mutation; hidden for view-only users of this feature.
+ *
+ *   <button *appHideForViewOnly="action.icon === 'upload'" ...>Upload</button>
+ *     -> hidden for view-only users only when the expression is true,
+ *        so navigation actions in the same *ngFor stay visible.
+ */
+@Directive({
+  selector: '[appHideForViewOnly]',
+  standalone: true,
+})
+export class HideForViewOnlyDirective implements OnInit {
+  private isMutation = true
+  private hasView = false
+  private initialized = false
+
+  constructor(
+    private templateRef: TemplateRef<unknown>,
+    private viewContainer: ViewContainerRef,
+    private access: FeatureAccessService,
+    @Optional() @Inject(FEATURE_KEY) private feature: FeatureKey | null,
+  ) {}
+
+  /**
+   * Marks whether the host element is a mutating action. A bare
+   * `*appHideForViewOnly` (empty string) is treated as a mutation. The setter
+   * may not fire for a value-less attribute, so the initial render happens in
+   * ngOnInit; this only re-renders on later value changes.
+   */
+  @Input('appHideForViewOnly')
+  set appHideForViewOnly(value: boolean | '') {
+    this.isMutation = value === '' || value === undefined ? true : Boolean(value)
+    if (this.initialized) {
+      this.updateView()
+    }
+  }
+
+  ngOnInit(): void {
+    this.initialized = true
+    this.updateView()
+  }
+
+  private updateView(): void {
+    const shouldHide = this.isMutation && this.access.isViewOnly(this.feature)
+    if (shouldHide && this.hasView) {
+      this.viewContainer.clear()
+      this.hasView = false
+    } else if (!shouldHide && !this.hasView) {
+      this.viewContainer.createEmbeddedView(this.templateRef)
+      this.hasView = true
+    }
+  }
+}

--- a/src/environments/env.util.ts
+++ b/src/environments/env.util.ts
@@ -2,7 +2,7 @@
  * Fallback roles that are always included even if window.env.portalRoles is missing.
  * Update this list when Jenkins/DevOps config is not yet set.
  */
-const DEFAULT_REQUIRED_ROLES: string[] = ['FRAC_ADMIN']
+const DEFAULT_REQUIRED_ROLES: string[] = ['FRAC_ADMIN', 'FRAC_READ', 'PLAYLIST_ADMIN', 'PLAYLIST_READ']
 
 type EnvMap = { [key: string]: any }
 


### PR DESCRIPTION
- Added directives to hide or disable action buttons and controls for view-only users.
- Updated components in the FRAC and Playlist features to utilize the new directives.
- Introduced a user guide for the Playlist feature detailing the user journey.
- Enhanced role-based access control by defining roles and their permissions for view-only access.
- Updated environment configuration to include new roles for view-only access.