### PR TITLE
feat(report-viewer): MNC CNE attendance report page (v1.1.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,177 @@
+# CLAUDE.md — sunbird-cb-orgportal
+
+Working agreements for this repo. These are **hard rules**; ask before deviating.
+
+---
+
+## 1. Workflow
+
+### Branch before editing
+Cut the branch **first**, before the first edit — never work directly on `production`.
+
+```bash
+git checkout -b feat/<short-desc>    # or fix/<short-desc>
+```
+
+| Branch | Role |
+|---|---|
+| `production` | Stable trunk. **Cut all feature/fix branches from here.** PRs target it. |
+| `release-X.Y.Z` | Frozen build branch. Jenkins deploys from this. **Never advance after deploy.** |
+| `main` | Exists but is **not** the dev base. Do not branch from it. |
+
+If edits were already started on `production`, `git checkout -b` carries them over — do that immediately rather than continuing.
+
+### Show the diff before applying it
+Show proposed changes as before/after code blocks in chat and wait for explicit confirmation ("yes", "go ahead") before calling Edit/Write.
+
+**Exception:** an approved plan (plan mode / ExitPlanMode) *is* the confirmation for the files that plan names. Anything outside the approved scope goes back to diff-first.
+
+### Commit and release are explicit triggers
+Never commit, push, or release on your own. Make the edits, report, and stop.
+
+| User says | Means |
+|---|---|
+| **"commit"** | `git commit` **and** `git push` for the current work. No PR, no release, unless asked. |
+| **"release"** | The full runbook in §5. |
+
+### No AI attribution, anywhere
+No `Co-Authored-By: Claude`, no "Generated with Claude Code", in commits, PR bodies, release notes, or docs.
+
+---
+
+## 2. Tests and builds — timing matters
+
+**Tests come after confirmation, not with the fix.** Ship the code change alone, let the user verify it in the running app, and add specs once they say it works.
+
+**Do not run the test suite or the production build until the user says "commit".** During the diagnose → fix loop, make edits and report. A fast type-check is fine; `ng test` and a prod build take minutes each and stall the loop. They batch into the commit step, where the build is the real gate.
+
+**Exception:** if an edit breaks an existing spec (e.g. a new constructor arg), fix that spec in the same change. Leaving the suite red is not "waiting", it is handing over broken work.
+
+When tests *are* requested:
+
+- Runner is **Karma + Jasmine** (`karma.conf.js`), not Jest. Angular 16 on this branch.
+- `npm test` → `ng test` runs the **`mdo` project only**; `tsconfig.spec.json` includes just `src/**/*.spec.ts`.
+- Specs under `project/ws/app/**` require **`ng test @ws/app`**. Flag this rather than silently editing config.
+- Service specs: copy [frac-api.service.spec.ts](project/ws/app/src/lib/routes/frac/services/frac-api.service.spec.ts) — the only spec using `HttpClientTestingModule`.
+- Component specs: copy [activity-upload.component.spec.ts](project/ws/app/src/lib/routes/frac/pages/activity/activity-upload/activity-upload.component.spec.ts) — `async beforeEach` + `await compileComponents()`, `jasmine.createSpyObj` + `of(...)`, `NO_ERRORS_SCHEMA`.
+- **Do not** copy `iframe-loader.component.spec.ts` or `frac.component.spec.ts` — stale CLI boilerplate that omits its own providers and throws `NullInjectorError`.
+
+---
+
+## 3. Angular rules (hard)
+
+Angular **16.2.12** on `production`; a 20.3.x migration is in flight. Either way:
+
+**Always:**
+- `standalone: false` on every component/pipe/directive. NgModule architecture is preserved.
+- `*ngIf` / `*ngFor` / `*ngSwitch`. **Never** `@if` / `@for` / `@switch`.
+- Constructor-based DI. **Never** `inject()`.
+- Stay NgModule-based — do not convert modules to standalone.
+- Import specifiers stay `@sunbird-cb/{collection,resolver,utils}`.
+- Material theming stays on the **M2** API (`mat.m2-define-palette`, …). Do not migrate to M3.
+
+> `project/ws/app/src/lib/routes/docs/common/ANGULAR_MODULE_GUIDELINES.md` §8.2 mandates standalone +
+> `loadComponent` and forbids feature modules. **The rules above win.** That doc reflects an aspiration
+> for the newest Playlist/FRAC code, not the standard for this repo.
+
+**Material legacy → MDC:** Angular 17 drops `MatLegacy*`. Replace `@angular/material/legacy-<x>` with `@angular/material/<x>` and `MatLegacyFoo`/`MAT_LEGACY_*` with `MatFoo`/`MAT_*`. Visually QA after — MDC markup and sizing differ.
+
+When MDC layout can't be fixed with reasonable CSS, **replace the component with native HTML** rather than escalating `!important` hacks.
+
+### The `!important` trap
+Global utility classes carry `!important` and win over component-level `!important` because of stylesheet injection order. Don't fight it — add a custom class instead.
+
+### Code style
+tslint (not eslint): **no semicolons**, max line length **140**, 2-space indent.
+
+---
+
+## 4. Code conventions
+
+**API endpoints** — module-level `API_END_POINTS` const of relative `/apis/...` strings; parameterized ones are arrow functions. See [event.service.ts](project/ws/app/src/lib/routes/home/services/event.service.ts#L6-L18). Endpoint URLs **never** come from `environment` in this repo. Never inline routes, limits, timeouts, or dialog dimensions in components.
+
+**`environment`** holds only `production`, `sitePath`, `karmYogiPath`, `cbpPath`, `portalRoles` — values injected at runtime via `window.env`. Feature toggles live in `instanceConfig` (read through `ConfigurationsService`), not `environment`.
+
+**Access control** — three levers, weakest to strongest:
+1. Menu visibility — `requiredRoles` on the menu item (host-served `assets/configurations/feature/home.json`).
+2. Page gate — `canActivate: [GeneralGuard]` + `data: { requiredRoles: ['some_role'] }`. **Lowercase required:** [general.guard.ts:124-132](src/app/guards/general.guard.ts#L124-L132) tests a lowercased Set without lowercasing the input, so an uppercase entry silently never matches.
+3. Within-page — the `FEATURE_ACCESS` / `FEATURE_KEY` / `*appHideForViewOnly` pattern in [feature-access.ts](project/ws/app/src/lib/shared/access/feature-access.ts). Note it hides *mutations* from read-role users; it does not gate a page, and `isViewOnly` fails **open**.
+
+**⚠ Adding a new role is a two-step job.** [env.util.ts](src/environments/env.util.ts) holds `DEFAULT_REQUIRED_ROLES`; at bootstrap `InitService.hasRole` intersects the user's roles against `environment.portalRoles` and calls `authSvc.logout()` on no match. A user holding **only** a role missing from that list is logged straight back out. Add it there (**uppercase** — that check is case-sensitive) *and* to DevOps `window.env.portalRoles`.
+
+**No i18n.** This repo has no translate pipe or i18n JSON — new strings go in templates directly. (Differs from the eagle-fusion sibling.)
+
+**Design work restyles existing components in place.** Do not scaffold new shared components or page sections for a design/token task.
+
+---
+
+## 5. Release runbook
+
+Trigger: user says "release" or "release X.Y.Z". Run through to the PR without stopping on automatable steps.
+
+| Artifact | Name |
+|---|---|
+| Build branch (Jenkins source) | `release-X.Y.Z` |
+| Tag | `vX.Y.Z` |
+| GitHub Release title | `Release-X.Y.Z` — version only, no date or description |
+| Notes file | `RELEASE_NOTES/release-X.Y.Z.md` |
+
+Branch name and tag name are always different — same name is an ambiguous git ref.
+
+1. **Verify green** — lint, unit tests, production build.
+2. **Work on a `feat/`/`fix/` branch.** Write `RELEASE_NOTES/release-X.Y.Z.md` on that **same** branch and commit it before opening the PR — one PR per release, not a separate notes PR.
+3. **One PR → merge into `production`.**
+4. **Wait for the merge.** Human-gated; do not proceed on an unmerged branch.
+5. **Cut artifacts from `production`** after merge: `git branch release-X.Y.Z origin/production && git tag vX.Y.Z origin/production`. Never cut from the feature branch.
+6. **Publish the GitHub Release** from the tag, body = the notes file, `--title "Release-X.Y.Z"` (it defaults to the tag name otherwise).
+7. **Deploy is manual** — Jenkins targets the **branch**, not the tag.
+8. **Never advance a frozen release branch.** Each release gets a fresh `release-X.Y.Z`.
+
+Older `cbrelease-X.Y.Z` / `Release-X.Y.Z` branches exist on the remote — no longer the convention.
+
+### Release notes structure
+Start from `RELEASE_NOTES/TEMPLATE.md` if present. Nine sections in order:
+
+1. Header table — build branch, tag, baseline, commit count, author
+2. **Summary** — 2–3 plain sentences for a non-engineer stakeholder
+3. ✨ Features (`_None — patch release._` if empty)
+4. 🐛 Fixes (`_None._` if empty)
+5. 🏗️ Build / CI / Infra
+6. 📚 Docs / Chore
+7. ⚠️ Deploy notes & risk — tick only what was actually touched
+8. ✅ Pre-deploy checklist — fill in the rollback ref
+9. Release & rollback — deploy source branch + rollback command
+
+Each bullet: `**<scope>** — <plain description> (\`<short-sha>\`)`. Always include the short SHA. Delete inapplicable deploy-note lines rather than leaving unchecked boxes.
+
+---
+
+## 6. Toolchain
+
+Node/npm come from **nvs** and are not on `PATH` by default. Prepend it in each command:
+
+```powershell
+$env:Path = "$env:LOCALAPPDATA\nvs\default;$env:Path"
+```
+
+| Command | Use |
+|---|---|
+| `npm run start:mdo-dev` | Dev server, proxies `/apis/*` to the stage host |
+| `npm run build` | Production build |
+| `npm test` | Karma, `mdo` project only |
+| `ng test @ws/app` | Specs under `project/ws/app/**` |
+| `npm run tailwind` | Regenerate `src/styles.scss` after new Tailwind classes |
+
+**Dev proxy cookie expires.** `proxy/localhost.proxy.json` hardcodes a session cookie for `/apis/*`. On local 401/403: log in to the stage host, copy the session cookie, update the `Cookie` header.
+
+**Path aliases:** `@ws/app` → `project/ws/app` public API. Relative imports only *within* the same feature.
+
+---
+
+## 7. Repo layout notes
+
+- The production Express server is committed at [dist/server.js](dist/server.js) — static gzip serving plus `http-proxy` for `/LA` and `/ScormCoursePlayer`. It has **no session awareness**; anything needing auth belongs in the sbportal backend behind `/apis/*`.
+- `assets/configurations/**` (menus, features, site config) is **host-served, not in this repo** — menu and nav changes are DevOps config, not code.
+- Existing S3 references point at `aastar-assets`, a **public** bucket. Never put personal or restricted data there.
+- `app/events` is declared twice in [app-routing.module.ts](src/app/app-routing.module.ts) (lines ~90 and ~162); the first wins, so the whole `app-event` feature is unreachable dead code. Don't add duplicate paths.
+- `home.rounting.module.ts` — filename misspelling is load-bearing; leave it.

--- a/RELEASE_NOTES/release-1.1.0.md
+++ b/RELEASE_NOTES/release-1.1.0.md
@@ -1,0 +1,57 @@
+# Release Notes — v1.1.0
+
+| | |
+|---|---|
+| **Build branch** | `release-1.1.0` |
+| **Tag** | `v1.1.0` _(to be created)_ |
+| **Baseline** | `8c6ae1f` — previous `production` tip |
+| **Commits** | 2 (2 features) |
+| **Author** | Likhith Thammegowda |
+| **Date** | 2026-08-06 |
+
+> Baseline is the previous `production` tip rather than a tag. The repo's only existing tag, `Release-1.0.0`, sits 32 commits behind `production`, so it would not describe what this release contains. `v1.1.0` starts the `release-X.Y.Z` / `vX.Y.Z` convention for this repo.
+
+## Summary
+
+Adds a new MNC Attendance Report page to the MDO portal, visible only to users granted a specific role. The report itself is a file the client refreshes daily; the portal displays it inside the page, served through the backend so it is never exposed as a public link. A left-menu entry is included so the intended users can reach it directly.
+
+## ✨ Features
+
+- **MNC attendance report page** — new `/app/home/mnc-attendance-report` route displaying the report in a sandboxed iframe, served from the `ui-proxy` backend. Gated by `GeneralGuard` on `mnc_report_viewer`, with handled states for forbidden and failed loads (`db96a3e`).
+- **Left-menu entry and display refinements** — surfaces the page in the left navigation via the existing `MenuConfigService` hook, gated on the same role; removes the duplicate page heading and timestamp, and removes the loading mechanism that could leave a spinner on screen indefinitely (`aac4cb7`).
+
+## 🐛 Fixes
+
+_None — new feature._
+
+## 🏗️ Build / CI / Infra
+
+_None._
+
+## 📚 Docs / Chore
+
+- **`CLAUDE.md`** — repo working agreements: branching, release runbook, test/build timing, Angular rules, code conventions and toolchain notes (`db96a3e`).
+- **`report-viewer/README.md`** — S3 layout, backend endpoint contract, role setup and verification steps for the report feature (`db96a3e`).
+
+## ⚠️ Deploy notes & risk
+
+- **⚠ `MNC_REPORT_VIEWER` must be added to `window.env.portalRoles` before deploy.** At bootstrap `InitService.hasRole` intersects a user's roles against `environment.portalRoles` and calls `authSvc.logout()` on no match, so a user holding **only** this role is logged straight back out. The role is present in `DEFAULT_REQUIRED_ROLES` in `src/environments/env.util.ts` as a fallback, but the deployed value comes from DevOps config. **Uppercase — that check is case-sensitive.**
+- **Requires ui-proxy v5.2.14 or later.** The page calls `/apis/protected/v8/report/mnc-attendance` and `/meta`. Against an older ui-proxy those return `403` and the page shows its "no access" state — degraded, not broken.
+- **Shared code touched: `MenuConfigService` was dormant and is now active.** Its import, injection and `mergeMenus` call in `home.component.ts` were all commented out; this release re-enables them. Its pre-existing Playlist and Competency entries are set `enabled: false`, since the merge had never run and their real entries come from the host-served page config — leaving them enabled would have duplicated nav items. **Worth a specific look at the left menu after deploy**, as this affects every user's navigation, not only report viewers.
+- **Route role name is lowercase (`mnc_report_viewer`)** in both the route guard and the menu entry: `GeneralGuard` tests a lowercased set without lowercasing its input, so an uppercase entry silently never matches.
+- No dependency, schema, or build-config changes.
+
+## ✅ Pre-deploy checklist
+
+- [ ] Lint + unit tests + production build pass on `production` at the release commit.
+- [ ] `MNC_REPORT_VIEWER` present in `window.env.portalRoles` (uppercase) for the target environment.
+- [ ] ui-proxy **v5.2.14 or later** is deployed.
+- [ ] A user with the role sees the menu entry and the report renders.
+- [ ] A user **without** the role is redirected away from `/app/home/mnc-attendance-report`.
+- [ ] Left menu verified for an existing `MDO_ADMIN` user — no missing or duplicated items after the `MenuConfigService` change.
+- [ ] Rollback reference confirmed: previous `production` tip `8c6ae1f`.
+
+## Release & rollback
+
+- **Deploy source:** `release-1.1.0`, cut from `production` at the release commit and tagged `v1.1.0`. Jenkins targets the branch, not the tag.
+- **Rollback:** re-run the deploy pipeline against a build of `8c6ae1f`. No data migration or config change needs reverting; leaving `MNC_REPORT_VIEWER` in `portalRoles` after a rollback is harmless.

--- a/project/ws/app/src/lib/routes/home/home.rounting.module.ts
+++ b/project/ws/app/src/lib/routes/home/home.rounting.module.ts
@@ -20,6 +20,7 @@ import { EventDetailsComponent } from './routes/event-details/event-details.comp
 import { EventOverviewComponent } from './routes/event-overview/event-overview.component'
 import { ParticipantsComponent } from './routes/participants/participants.component'
 import { CertificateGeneratorComponent } from './routes/certificate-generator/certificate-generator.component'
+import { GeneralGuard } from '../../../../../../../src/app/guards/general.guard'
 
 const routes: Routes = [
   {
@@ -119,6 +120,16 @@ const routes: Routes = [
         path: 'frac',
         loadChildren: () =>
           import('../frac/frac.module').then((m) => m.FracModule),
+      },
+      {
+        // Role name MUST be lowercase — GeneralGuard tests a lowercased Set without
+        // lowercasing the input, so an uppercase entry silently never matches.
+        // This gate is for UX; the backend 403 is the real access control.
+        path: 'mnc-attendance-report',
+        loadChildren: () =>
+          import('../report-viewer/report-viewer.module').then((m) => m.ReportViewerModule),
+        canActivate: [GeneralGuard],
+        data: { requiredRoles: ['mnc_report_viewer'] },
       }
     ],
   },

--- a/project/ws/app/src/lib/routes/home/routes/home/home.component.ts
+++ b/project/ws/app/src/lib/routes/home/routes/home/home.component.ts
@@ -3,7 +3,7 @@ import { Router, Event, NavigationEnd, ActivatedRoute } from '@angular/router'
 import { ConfigurationsService, ValueService } from '@sunbird-cb/utils'
 import { map } from 'rxjs/operators'
 import { NsWidgetResolver } from '@sunbird-cb/resolver'
-// import { MenuConfigService } from '../../services/menu-config.service'
+import { MenuConfigService } from '../../services/menu-config.service'
 /* tslint:disable */
 import _ from 'lodash'
 import { ILeftMenu } from '@sunbird-cb/collection'
@@ -52,7 +52,7 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
     private router: Router,
     private activeRoute: ActivatedRoute,
     private configService: ConfigurationsService,
-    // private menuConfig: MenuConfigService
+    private menuConfig: MenuConfigService
   ) {
     if (_.get(this.activeRoute, 'snapshot.data.configService.userRoles')) {
       this.myRoles = _.get(this.activeRoute, 'snapshot.data.configService.userRoles')
@@ -70,8 +70,8 @@ export class HomeComponent implements OnInit, AfterViewInit, OnDestroy {
           let leftData = _.get(this.activeRoute.snapshot, 'data.pageData.data.menus', [])
           // Ensure leftData.widgetData exists before filtering
           if (leftData.widgetData && Array.isArray(leftData.widgetData.menus)) {
-            // Merge local menus (e.g., Playlist) with API menus
-            // leftData.widgetData.menus = this.menuConfig.mergeMenus(leftData.widgetData.menus)
+            // Merge locally-configured menus (not yet in the page API) with the API menus
+            leftData.widgetData.menus = this.menuConfig.mergeMenus(leftData.widgetData.menus)
             console.log('After merge:', leftData.widgetData.menus.map((m: any) => ({ name: m.name, key: m.key, routerLink: m.routerLink })))
             // Filter menus based on user roles
             leftData.widgetData.menus = leftData.widgetData.menus.filter((menu: { requiredRoles: any[] }) => {

--- a/project/ws/app/src/lib/routes/home/services/menu-config.service.ts
+++ b/project/ws/app/src/lib/routes/home/services/menu-config.service.ts
@@ -13,6 +13,24 @@ export class MenuConfigService {
      */
     private readonly localMenus = [
         {
+            name: 'MNC Attendance Report',
+            key: 'mncAttendanceReport',
+            fragment: false,
+            render: true,
+            badges: {
+                enabled: false,
+                uri: ''
+            },
+            enabled: true,
+            routerLink: '/app/home/mnc-attendance-report',
+            // Lowercase: the left-menu widget matches against the lowercased userRoles set.
+            requiredRoles: ['mnc_report_viewer'],
+        },
+        // Playlist and Competency are left disabled deliberately. mergeMenus() was switched
+        // off entirely until now, so neither has ever been rendered from here — their real
+        // menu entries come from the host-served page config. Enabling them as a side effect
+        // of turning mergeMenus back on would surface duplicate/unreviewed nav items.
+        {
             name: 'Playlist',
             key: 'playlist',
             fragment: false,
@@ -21,7 +39,7 @@ export class MenuConfigService {
                 enabled: false,
                 uri: ''
             },
-            enabled: true,
+            enabled: false,
             routerLink: '/app/home/playlist/filters',
             requiredRoles: ['admin', 'mdo_admin', 'wat_member'],
         },
@@ -34,7 +52,7 @@ export class MenuConfigService {
                 enabled: false,
                 uri: ''
             },
-            enabled: true,
+            enabled: false,
             routerLink: '/app/home/competency/summary',
             requiredRoles: ['admin', 'mdo_admin', 'wat_member'],
         },

--- a/project/ws/app/src/lib/routes/report-viewer/README.md
+++ b/project/ws/app/src/lib/routes/report-viewer/README.md
@@ -1,0 +1,132 @@
+# MNC Attendance Report Viewer
+
+Displays a client-supplied HTML dashboard, held in a **private S3 bucket** and overwritten daily
+at a fixed key, to a small set of users.
+
+Route: `/app/home/mnc-attendance-report` — gated on role `mnc_report_viewer`.
+
+## Why it is built this way
+
+The report is a single **self-contained** 9.9 MB HTML file: one 9.87 MB line of base64-of-gzip roster
+data, inflated in-browser via `atob` + `DecompressionStream("gzip")`. It has no `<script src>`,
+`<link>`, `<img>`, no `url()`, no `fetch`/XHR, and no `localStorage`/cookie/parent-frame access.
+
+| Consequence | Design outcome |
+|---|---|
+| No sibling objects to fetch | One object served from one endpoint is enough |
+| Needs no same-origin capability | `sandbox="allow-scripts"` alone → opaque origin, real isolation |
+| Contains a **named attendance roster** | Access must be gated server-side, not by URL secrecy |
+| Same URL, content changes daily | Stable URL + `ETag` → `304` revalidation is the caching strategy |
+
+**A presigned S3 URL was rejected deliberately.** A signed URL is a bearer credential: shareable, and
+it lands in browser history and server logs — wrong for personal data restricted to a few people. It
+also *breaks* caching here: the signature lives in the query string, so each freshly-minted URL is a
+new cache key and every view re-downloads the whole file.
+
+## Part 1 — S3 setup (one-time infra)
+
+> **Do not reuse the `aastar-assets` bucket.** Existing S3 references in this repo treat it as a
+> **public** bucket. Putting a personal-data roster there would publish it.
+
+New bucket in `ap-south-1`:
+
+| Setting | Value |
+|---|---|
+| Block Public Access | **All four ON** |
+| Versioning | **Enabled** — rollback for a bad daily upload |
+| Default encryption | SSE-S3 |
+| Key (stable, overwritten daily) | `reports/mnc-cne-attendance/latest.html` |
+| Lifecycle rule | Expire **noncurrent** versions after 30 days |
+
+Without the lifecycle rule, ~10 MB/day of versions accumulates indefinitely.
+
+**IAM — two principals, least privilege:**
+
+- sbportal: `s3:GetObject` on `reports/mnc-cne-attendance/*` only. (`HeadObject` needs no extra permission.)
+- The client's upload identity: `s3:PutObject` on that one key only — no read, no delete.
+
+S3 overwrites are strongly read-after-write consistent, so a new upload is visible immediately.
+
+The daily upload mechanism itself is the client's responsibility. **The backend must therefore not
+depend on them setting the right object metadata** — see the compression note below.
+
+## Part 2 — Backend endpoints (`org-sphere/sbportal` — separate repo)
+
+Both routes sit behind the existing session middleware **and** a `MNC_REPORT_VIEWER` role check.
+
+### `GET /apis/protected/v8/report/mnc-attendance/meta`
+
+Returns `{ lastModified, etag, sizeBytes }`, backed by `HeadObject` (no body transfer).
+
+This exists because **an iframe cannot report an HTTP status** — it would render a 403 body as if it
+were the report. The component probes this first, so authorization failures become a handled error
+state, and the `lastModified` drives the "Last updated" label that tells users whether today's data
+actually landed.
+
+### `GET /apis/protected/v8/report/mnc-attendance`
+
+1. **403** if the session lacks the role. Do not fall through to serving.
+2. `HeadObject` → ETag. If the request's `If-None-Match` matches, return **304 with no body.**
+   This is the whole caching win — implement it before anything else.
+3. Otherwise `GetObject` and stream:
+
+| Header | Value |
+|---|---|
+| `Content-Type` | `text/html; charset=utf-8` |
+| `ETag` | S3's ETag, verbatim |
+| `Cache-Control` | `private, no-cache` |
+| `X-Content-Type-Options` | `nosniff` |
+| `Content-Disposition` | `inline` |
+
+`no-cache` means "cache the bytes but always revalidate" — **not** "don't cache". That is exactly right
+for daily-changing content at a fixed URL: a full local copy, a tiny revalidation request, and a
+re-download only when the content actually changed.
+
+**Compression — robust to either upload style.** Read the object's `ContentEncoding`. If it is already
+`gzip`, pass the bytes through and set `Content-Encoding: gzip`; otherwise let the standard compression
+middleware gzip on the fly. Measured: 9.9 MB → **7.13 MB**. The ratio is modest because the payload is
+already-gzipped data that was then base64'd, so re-compressing only claws back part of base64's 33%
+expansion.
+
+> ⚠ Verify the compression middleware does not rewrite the `ETag`. If it does, 304s silently stop
+> working and every view re-downloads ~7 MB.
+
+## Part 3 — The role
+
+`MNC_REPORT_VIEWER` (uppercase from the API) → `mnc_report_viewer` (lowercase in `configSvc.userRoles`).
+Create it in the Sunbird/Keycloak role master and assign it to the designated users.
+
+### ⚠ Two-step, or those users cannot log in at all
+
+`InitService.hasRole` intersects the user's raw API roles against `environment.portalRoles` at bootstrap
+and calls `authSvc.logout()` on no match. A user holding **only** this role would be logged straight
+back out.
+
+1. ✅ Added to `DEFAULT_REQUIRED_ROLES` in [env.util.ts](../../../../../../../src/environments/env.util.ts) (**uppercase** — that check is case-sensitive).
+2. ⬜ **DevOps must also add it to `window.env.portalRoles`**, which is merged with the defaults at runtime.
+
+## Part 4 — Navigation entry (outside this repo)
+
+The left menu is driven by host-served `assets/configurations/feature/home.json`. Add an item pointing
+at `/app/home/mnc-attendance-report` with `requiredRoles: ['mnc_report_viewer']`. This is the same path
+FRAC uses — it has no in-repo menu entry either.
+
+Until that lands the page is reachable by direct link, which is acceptable for a handful of users.
+
+## Verification
+
+1. **Role gate** — without the role, `/app/home/mnc-attendance-report` redirects to `/page/home`; with it, the page renders.
+2. **Login blocker** — log in as a user holding *only* `MNC_REPORT_VIEWER` and confirm you are not
+   immediately logged out. Most likely step to fail; validates Part 3.
+3. **Rendering** — charts draw, light and dark both legible, no console errors. Confirms
+   `DecompressionStream` runs under the sandbox's opaque origin.
+4. **Caching** — DevTools Network: first load ~7 MB; reload → **304**, near-zero transfer; overwrite the
+   S3 object and reload → full body with new content. If reload 2 re-downloads everything, ETag
+   propagation is broken (check the compression middleware).
+5. **Direct access** — request the content URL with no portal session → **403**, not HTML.
+6. **Isolation** — confirm the iframe cannot reach `parent.document`.
+
+## Out of scope
+
+Upload tooling (client's responsibility), browsable history of past days, and CloudFront + signed
+cookies — worth revisiting only if the audience grows well beyond a few people.

--- a/project/ws/app/src/lib/routes/report-viewer/components/report-viewer/report-viewer.component.html
+++ b/project/ws/app/src/lib/routes/report-viewer/components/report-viewer/report-viewer.component.html
@@ -1,0 +1,42 @@
+<div class="report-viewer">
+
+  <div class="report-viewer__header" *ngIf="!errorType">
+    <h2 class="report-viewer__title">MNC CNE Attendance Sync</h2>
+    <span class="report-viewer__updated" *ngIf="lastUpdated">
+      Last updated: {{ lastUpdated | date: 'dd MMM yyyy, h:mm a' }}
+    </span>
+  </div>
+
+  <div class="report-viewer__state" *ngIf="isMetaLoading || isReportLoading">
+    <mat-spinner [diameter]="40"></mat-spinner>
+    <p class="report-viewer__state-text">
+      <ng-container *ngIf="isMetaLoading">Checking report availability&hellip;</ng-container>
+      <ng-container *ngIf="!isMetaLoading">Loading report &mdash; this may take a moment.</ng-container>
+    </p>
+  </div>
+
+  <div class="report-viewer__state" *ngIf="errorType === 'forbidden'">
+    <mat-icon class="report-viewer__state-icon">lock</mat-icon>
+    <p class="report-viewer__state-text">You don't have access to this report.</p>
+  </div>
+
+  <div class="report-viewer__state" *ngIf="errorType === 'generic'">
+    <mat-icon class="report-viewer__state-icon">error_outline</mat-icon>
+    <p class="report-viewer__state-text">The report could not be loaded.</p>
+    <button mat-stroked-button color="primary" (click)="loadReport()">Retry</button>
+  </div>
+
+  <!--
+    sandbox="allow-scripts" without allow-same-origin is deliberate: it forces an opaque
+    origin, so the report cannot reach the portal's DOM or cookies. Safe here because the
+    report is self-contained and uses no storage, cookies or parent-frame access.
+  -->
+  <iframe *ngIf="iframeSrc"
+          title="MNC CNE Attendance Sync"
+          class="report-viewer__frame"
+          [class.report-viewer__frame--hidden]="isReportLoading"
+          sandbox="allow-scripts"
+          [src]="iframeSrc"
+          (load)="onReportLoaded()"></iframe>
+
+</div>

--- a/project/ws/app/src/lib/routes/report-viewer/components/report-viewer/report-viewer.component.html
+++ b/project/ws/app/src/lib/routes/report-viewer/components/report-viewer/report-viewer.component.html
@@ -1,18 +1,18 @@
 <div class="report-viewer">
 
-  <div class="report-viewer__header" *ngIf="!errorType">
-    <h2 class="report-viewer__title">MNC CNE Attendance Sync</h2>
-    <span class="report-viewer__updated" *ngIf="lastUpdated">
-      Last updated: {{ lastUpdated | date: 'dd MMM yyyy, h:mm a' }}
-    </span>
-  </div>
+  <!--
+    No title or "last updated" here on purpose: the report HTML already renders its own
+    heading and generation timestamp, so repeating them duplicated the same information.
+  -->
 
-  <div class="report-viewer__state" *ngIf="isMetaLoading || isReportLoading">
+  <!--
+    Shown only while the metadata probe is in flight. The report itself is NOT gated behind
+    a spinner: it is several megabytes and renders progressively, and hiding it until an
+    iframe `load` event meant a stuck spinner whenever that event did not fire.
+  -->
+  <div class="report-viewer__state" *ngIf="isMetaLoading">
     <mat-spinner [diameter]="40"></mat-spinner>
-    <p class="report-viewer__state-text">
-      <ng-container *ngIf="isMetaLoading">Checking report availability&hellip;</ng-container>
-      <ng-container *ngIf="!isMetaLoading">Loading report &mdash; this may take a moment.</ng-container>
-    </p>
+    <p class="report-viewer__state-text">Loading report&hellip;</p>
   </div>
 
   <div class="report-viewer__state" *ngIf="errorType === 'forbidden'">
@@ -34,9 +34,7 @@
   <iframe *ngIf="iframeSrc"
           title="MNC CNE Attendance Sync"
           class="report-viewer__frame"
-          [class.report-viewer__frame--hidden]="isReportLoading"
           sandbox="allow-scripts"
-          [src]="iframeSrc"
-          (load)="onReportLoaded()"></iframe>
+          [src]="iframeSrc"></iframe>
 
 </div>

--- a/project/ws/app/src/lib/routes/report-viewer/components/report-viewer/report-viewer.component.scss
+++ b/project/ws/app/src/lib/routes/report-viewer/components/report-viewer/report-viewer.component.scss
@@ -1,0 +1,66 @@
+.report-viewer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+
+  &__header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 16px 20px 12px;
+  }
+
+  &__title {
+    margin: 0;
+    font-size: 20px;
+    font-weight: 600;
+  }
+
+  /* The report is regenerated daily — surface the upload time so a stale day is visible. */
+  &__updated {
+    font-size: 13px;
+    opacity: 0.7;
+  }
+
+  &__state {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 48px 20px;
+    text-align: center;
+  }
+
+  &__state-icon {
+    font-size: 40px;
+    width: 40px;
+    height: 40px;
+    opacity: 0.55;
+  }
+
+  &__state-text {
+    margin: 0;
+    font-size: 14px;
+    opacity: 0.75;
+  }
+
+  &__frame {
+    flex: 1 1 auto;
+    width: 100%;
+    min-height: 70vh;
+    border: 0;
+
+    /* Kept in the DOM while loading — an iframe must be attached to fetch its src. */
+    &--hidden {
+      visibility: hidden;
+      position: absolute;
+      height: 0;
+      min-height: 0;
+    }
+  }
+}

--- a/project/ws/app/src/lib/routes/report-viewer/components/report-viewer/report-viewer.component.scss
+++ b/project/ws/app/src/lib/routes/report-viewer/components/report-viewer/report-viewer.component.scss
@@ -4,27 +4,6 @@
   height: 100%;
   min-height: 0;
 
-  &__header {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 8px;
-    padding: 16px 20px 12px;
-  }
-
-  &__title {
-    margin: 0;
-    font-size: 20px;
-    font-weight: 600;
-  }
-
-  /* The report is regenerated daily — surface the upload time so a stale day is visible. */
-  &__updated {
-    font-size: 13px;
-    opacity: 0.7;
-  }
-
   &__state {
     display: flex;
     flex: 1 1 auto;
@@ -49,18 +28,11 @@
     opacity: 0.75;
   }
 
+  /* No portal chrome above the frame, so give the report the full viewport height. */
   &__frame {
     flex: 1 1 auto;
     width: 100%;
-    min-height: 70vh;
+    min-height: 90vh;
     border: 0;
-
-    /* Kept in the DOM while loading — an iframe must be attached to fetch its src. */
-    &--hidden {
-      visibility: hidden;
-      position: absolute;
-      height: 0;
-      min-height: 0;
-    }
   }
 }

--- a/project/ws/app/src/lib/routes/report-viewer/components/report-viewer/report-viewer.component.ts
+++ b/project/ws/app/src/lib/routes/report-viewer/components/report-viewer/report-viewer.component.ts
@@ -1,0 +1,81 @@
+import { HttpErrorResponse } from '@angular/common/http'
+import { Component, OnDestroy, OnInit } from '@angular/core'
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser'
+import { Subscription } from 'rxjs'
+import { ReportViewerService } from '../../services/report-viewer.service'
+
+export type TReportError = 'forbidden' | 'generic'
+
+@Component({
+  selector: 'ws-app-report-viewer',
+  templateUrl: './report-viewer.component.html',
+  styleUrls: ['./report-viewer.component.scss'],
+  standalone: false,
+})
+export class ReportViewerComponent implements OnInit, OnDestroy {
+
+  iframeSrc: SafeResourceUrl | null = null
+  lastUpdated: string | null = null
+
+  /** True while the cheap metadata probe is in flight. */
+  isMetaLoading = true
+  /** True from the moment the iframe src is set until the iframe fires `load`. */
+  isReportLoading = false
+  errorType: TReportError | null = null
+
+  private metaSubscription: Subscription | null = null
+
+  constructor(
+    private domSanitizer: DomSanitizer,
+    private reportViewerSvc: ReportViewerService,
+  ) { }
+
+  ngOnInit() {
+    this.loadReport()
+  }
+
+  ngOnDestroy() {
+    if (this.metaSubscription) {
+      this.metaSubscription.unsubscribe()
+    }
+  }
+
+  /**
+   * Probes the report metadata first, then points the iframe at the content URL. Ordering
+   * matters: a failed request inside an iframe would render the error body as if it were
+   * the report, so authorization is resolved before the src is ever bound.
+   */
+  loadReport(): void {
+    this.resetState()
+    this.metaSubscription = this.reportViewerSvc.getReportMeta().subscribe(
+      meta => {
+        this.lastUpdated = (meta && meta.lastModified) || null
+        this.isMetaLoading = false
+        this.isReportLoading = true
+        this.setIframeSource(this.reportViewerSvc.getReportContentUrl())
+      },
+      (error: HttpErrorResponse) => {
+        this.isMetaLoading = false
+        this.errorType = error && error.status === 403 ? 'forbidden' : 'generic'
+      },
+    )
+  }
+
+  /** Bound to the iframe's `load` event — the report body runs to several megabytes. */
+  onReportLoaded(): void {
+    this.isReportLoading = false
+  }
+
+  private resetState(): void {
+    this.iframeSrc = null
+    this.lastUpdated = null
+    this.isMetaLoading = true
+    this.isReportLoading = false
+    this.errorType = null
+  }
+
+  /** Sanitizes the report URL before binding it in the template. */
+  private setIframeSource(url: string): void {
+    this.iframeSrc = this.domSanitizer.bypassSecurityTrustResourceUrl(url)
+  }
+}

--- a/project/ws/app/src/lib/routes/report-viewer/components/report-viewer/report-viewer.component.ts
+++ b/project/ws/app/src/lib/routes/report-viewer/components/report-viewer/report-viewer.component.ts
@@ -15,12 +15,9 @@ export type TReportError = 'forbidden' | 'generic'
 export class ReportViewerComponent implements OnInit, OnDestroy {
 
   iframeSrc: SafeResourceUrl | null = null
-  lastUpdated: string | null = null
 
   /** True while the cheap metadata probe is in flight. */
   isMetaLoading = true
-  /** True from the moment the iframe src is set until the iframe fires `load`. */
-  isReportLoading = false
   errorType: TReportError | null = null
 
   private metaSubscription: Subscription | null = null
@@ -48,10 +45,10 @@ export class ReportViewerComponent implements OnInit, OnDestroy {
   loadReport(): void {
     this.resetState()
     this.metaSubscription = this.reportViewerSvc.getReportMeta().subscribe(
-      meta => {
-        this.lastUpdated = (meta && meta.lastModified) || null
+      () => {
+        // The response body is not needed — this call exists so an authorization or
+        // storage failure surfaces as a handled state before the iframe src is bound.
         this.isMetaLoading = false
-        this.isReportLoading = true
         this.setIframeSource(this.reportViewerSvc.getReportContentUrl())
       },
       (error: HttpErrorResponse) => {
@@ -61,16 +58,9 @@ export class ReportViewerComponent implements OnInit, OnDestroy {
     )
   }
 
-  /** Bound to the iframe's `load` event — the report body runs to several megabytes. */
-  onReportLoaded(): void {
-    this.isReportLoading = false
-  }
-
   private resetState(): void {
     this.iframeSrc = null
-    this.lastUpdated = null
     this.isMetaLoading = true
-    this.isReportLoading = false
     this.errorType = null
   }
 

--- a/project/ws/app/src/lib/routes/report-viewer/report-viewer-routing.module.ts
+++ b/project/ws/app/src/lib/routes/report-viewer/report-viewer-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core'
+import { RouterModule } from '@angular/router'
+import { ReportViewerComponent } from './components/report-viewer/report-viewer.component'
+
+@NgModule({
+  imports: [
+    RouterModule.forChild([
+      {
+        path: '',
+        component: ReportViewerComponent,
+      },
+    ]),
+  ],
+  exports: [RouterModule],
+})
+export class ReportViewerRoutingModule { }

--- a/project/ws/app/src/lib/routes/report-viewer/report-viewer.module.ts
+++ b/project/ws/app/src/lib/routes/report-viewer/report-viewer.module.ts
@@ -1,0 +1,19 @@
+import { CommonModule } from '@angular/common'
+import { NgModule } from '@angular/core'
+import { MatButtonModule } from '@angular/material/button'
+import { MatIconModule } from '@angular/material/icon'
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
+import { ReportViewerComponent } from './components/report-viewer/report-viewer.component'
+import { ReportViewerRoutingModule } from './report-viewer-routing.module'
+
+@NgModule({
+  declarations: [ReportViewerComponent],
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    ReportViewerRoutingModule,
+  ],
+})
+export class ReportViewerModule { }

--- a/project/ws/app/src/lib/routes/report-viewer/services/report-viewer.service.ts
+++ b/project/ws/app/src/lib/routes/report-viewer/services/report-viewer.service.ts
@@ -1,0 +1,45 @@
+import { HttpClient } from '@angular/common/http'
+import { Injectable } from '@angular/core'
+import { Observable } from 'rxjs'
+
+const PROTECTED_SLAG_V8 = '/apis/protected/v8'
+
+/**
+ * The report HTML is a single self-contained object in a private S3 bucket, overwritten
+ * daily by the client at a fixed key. The backend streams it from a stable URL so that
+ * ETag/304 revalidation works — the multi-megabyte body only transfers on days the
+ * content actually changed.
+ */
+const API_END_POINTS = {
+  REPORT_META: `${PROTECTED_SLAG_V8}/report/mnc-attendance/meta`,
+  REPORT_CONTENT: `${PROTECTED_SLAG_V8}/report/mnc-attendance`,
+}
+
+export interface IReportMeta {
+  /** ISO-8601 timestamp of the last S3 upload. */
+  lastModified: string
+  etag: string
+  sizeBytes: number
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ReportViewerService {
+
+  constructor(private http: HttpClient) { }
+
+  /**
+   * Cheap HeadObject-backed probe. Called before the iframe is pointed at the content URL
+   * so that authorization failures surface as a handled error state — an iframe cannot
+   * report an HTTP status, it would simply render the error body.
+   */
+  getReportMeta(): Observable<IReportMeta> {
+    return this.http.get<IReportMeta>(API_END_POINTS.REPORT_META)
+  }
+
+  /** Stable same-origin URL bound to the iframe once `getReportMeta` succeeds. */
+  getReportContentUrl(): string {
+    return API_END_POINTS.REPORT_CONTENT
+  }
+}

--- a/src/environments/env.util.ts
+++ b/src/environments/env.util.ts
@@ -2,7 +2,13 @@
  * Fallback roles that are always included even if window.env.portalRoles is missing.
  * Update this list when Jenkins/DevOps config is not yet set.
  */
-const DEFAULT_REQUIRED_ROLES: string[] = ['FRAC_ADMIN', 'FRAC_READ', 'PLAYLIST_ADMIN', 'PLAYLIST_READ']
+const DEFAULT_REQUIRED_ROLES: string[] = [
+  'FRAC_ADMIN',
+  'FRAC_READ',
+  'PLAYLIST_ADMIN',
+  'PLAYLIST_READ',
+  'MNC_REPORT_VIEWER',
+]
 
 type EnvMap = { [key: string]: any }
 


### PR DESCRIPTION
Adds the MNC Attendance Report page, plus `RELEASE_NOTES/release-1.1.0.md`.

## What

New `/app/home/mnc-attendance-report` route displaying the client's daily report in a sandboxed iframe, served through ui-proxy from a private S3 bucket. Visible only to holders of `mnc_report_viewer`, with a left-menu entry gated on the same role.

## Notes for review

- **`sandbox="allow-scripts"` without `allow-same-origin`** is deliberate. It forces an opaque origin, so the report cannot reach the portal's DOM or cookies. Safe because the report is self-contained and uses no storage, cookies or parent-frame access.
- **`/meta` is probed before the iframe src is bound.** An iframe cannot surface an HTTP status — it would render a 403 body as though it were the report — so authorization is resolved first and mapped to a handled state.
- **Role names are lowercase** in the route guard and menu entry. `GeneralGuard` tests a lowercased set without lowercasing its input, so an uppercase entry silently never matches.
- **`MNC_REPORT_VIEWER` added to `DEFAULT_REQUIRED_ROLES`** in `env.util.ts`. `InitService.hasRole` logs out any user whose roles don't intersect `environment.portalRoles`, so without it a user holding only this role is logged straight back out.

## ⚠ Shared code: `MenuConfigService` was dormant and is now active

Its import, injection and `mergeMenus` call in `home.component.ts` were all commented out. This PR re-enables them to add the menu entry in code rather than via host config. Its pre-existing **Playlist** and **Competency** entries are set `enabled: false` — the merge had never run, and their real entries come from the host-served page config, so leaving them on would have duplicated nav items.

This affects **every user's left menu**, not just report viewers. Please sanity-check the menu as an existing `MDO_ADMIN` rather than only as a report user.

## Deploy prerequisites

- **`MNC_REPORT_VIEWER` in `window.env.portalRoles`** (uppercase) — otherwise report-only users are logged out at bootstrap
- **ui-proxy v5.2.14+** — against anything older the page renders its "no access" state

## Verified

Tested end to end locally against the real S3 object: report renders, menu entry appears and routes correctly, a user without the role is redirected, `tsc --noEmit` 0 errors.

Also removes an earlier loading mechanism that depended on the iframe `(load)` event and could leave a spinner on screen permanently, and drops a duplicate title/timestamp that the report already renders itself.
