### PR TITLE
Release 2.1.0: fix jest specs + release notes

### DIFF
--- a/RELEASE_NOTES/release-2.1.0.md
+++ b/RELEASE_NOTES/release-2.1.0.md
@@ -1,0 +1,80 @@
+# Release 2.1.0 — 2026-08-17
+
+|                              |                                                |
+| ---------------------------- | ---------------------------------------------- |
+| **Build branch deployed**    | `release-2.1.0` (Jenkins deploy source)      |
+| **Tag**                      | `v2.1.0` (immutable marker + GitHub Release) |
+| **Baseline (previous prod)** | `v2.0.0`                                     |
+| **Commits**                  | `2`                                          |
+| **Author**                   | Pavithra Prakash                             |
+
+## Summary
+
+Follow-up release on top of 2.0.0: fixes all 9 jest specs left failing after the Angular
+20 migration (no production code changed — the fixes were all in the tests themselves),
+and documents the README/ARCHITECTURE refresh and Sonar quality-gateway setup that shipped
+in `v2.0.0` but wasn't captured in that release's notes.
+
+## 🐛 Fixes
+
+- **tests** — Fixed all 9 failing jest specs left over from the Angular 20 migration; zero
+  production source changes. Root causes: a broken `Object.defineProperty` Blob-mock hack
+  that silently swallowed its own read, a `jest.mock('moment')` missing a proper `.default`
+  export shape, an incorrect assertion in a competency-labels test that didn't match the
+  component's actual (correct) branch behavior, a couple of loose TS types on mock call
+  tuples, and 4 specs that all failed identically because `ngx-export-as` transitively pulls
+  in `html2pdf.js`, a CJS bundle Jest can't parse — mocked out `ngx-export-as` in those 4.
+  Full suite: 248/248 suites, 3840/3841 tests passing (1 pre-existing skip). (`ae4bc29`)
+
+## 📚 Docs / Chore
+
+- **docs** — Verified and corrected README.md and ARCHITECTURE.md against the actual
+  Angular 20 codebase (tech-stack versions, corrected a stale claim that standalone
+  components/signals were repo-wide — they're a documented Playlist-module-only exception
+  per `MIGRATION.md` PR-6/PR-4), and added a Code Quality Gateway section documenting the
+  GitHub Actions + SonarCloud/SonarQube gate and two real config gaps found while verifying
+  (stale Karma/Jasmine flags in the CI test step, and a coverage-path mismatch between
+  `sonar-project.properties` and the actual Jest output directory). Also added a
+  `📊 Sonar / Code Quality Report` section to `RELEASE_NOTES/TEMPLATE.md` for future
+  releases to fill in at cut time. _(Note: this commit predates this release's baseline —
+  it already shipped inside `v2.0.0` via PR #44, but wasn't mentioned in that release's
+  notes; documented here for completeness.)_ (`1cd8637`)
+
+## 📊 Sonar / Code Quality Report
+
+> Pulled 2026-08-17 from the [live dashboard](https://sonar.aastrika.org/dashboard?id=sphere-cb-orgPortal)
+> (last analysis 2026-08-10). Sonar analyses on this project aren't tied to release tags
+> (all recorded runs show `projectVersion: "1.0"`), so this snapshot predates this specific
+> commit and should be re-pulled once a fresh analysis runs against `release-2.1.0`.
+
+| Metric | Value |
+|---|---|
+| Quality Gate | ❌ FAIL — 187 new-code violations (gate: 0) |
+| New code coverage | 83.8% (gate: ≥ 80% — passing) |
+| New duplicated lines | 0.15% (gate: ≤ 3% — passing) |
+| Overall coverage | 90.5% |
+| Bugs / Vulnerabilities | 0 / 0 |
+| Code smells | 2,716 |
+| Security hotspots reviewed | 100% |
+
+## ⚠️ Deploy notes & risk
+
+- **Migration/deploy gotchas touched?** None — no production source changed in this release.
+- **Config / env / secret changes:** none.
+- **Backend / API contract dependencies:** none.
+- **Breaking changes:** none.
+
+## ✅ Pre-deploy checklist
+
+- [x] Build verified (`npm run build`)
+- [ ] `npm run lint` — not clean (154 pre-existing errors/warnings, unrelated to this
+      release; see `README.md` Code Quality Gateway section)
+- [x] Unit tests green (`npm test` — 248/248 suites, 3840/3841 passing)
+- [ ] Smoke-tested on preprod
+- [ ] Rollback ref confirmed (re-runnable in Jenkins): `release-2.0.0`
+
+## Release & rollback
+
+**Deploy** — a human runs the manual Jenkins job (`Jenkinsfile-sun`) pointed at the **build branch** `release-2.1.0` (deploy is from a branch, not a tag). Each release gets its own new build branch + a `v2.1.0` tag; the previous `release-2.0.0` branch stays frozen.
+
+**Rollback** — re-run the same manual Jenkins job against the previous release branch `release-2.0.0`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mdo",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "scripts": {
         "ng": "ng",
         "start": "node --max_old_space_size=8000 ./node_modules/@angular/cli/bin/ng serve --proxy-config proxy/localhost.proxy.json -o",

--- a/project/ws/app/src/lib/routes/events/routes/list/list-event.component.spec.ts
+++ b/project/ws/app/src/lib/routes/events/routes/list/list-event.component.spec.ts
@@ -1,7 +1,6 @@
 jest.mock('moment', () => {
   const actualMoment = jest.requireActual('moment')
-  Object.defineProperty(actualMoment, '__esModule', { value: true })
-  return actualMoment
+  return { __esModule: true, default: actualMoment }
 })
 
 import { ComponentFixture, TestBed } from '@angular/core/testing'

--- a/project/ws/app/src/lib/routes/frac/utils/frac-response-parser.util.spec.ts
+++ b/project/ws/app/src/lib/routes/frac/utils/frac-response-parser.util.spec.ts
@@ -23,20 +23,6 @@ describe('FracResponseParserUtil', () => {
       JSON.stringify({ responseCode: 'CLIENT_ERROR', params: { errmsg: 'invalid file' } }),
     ], { type: 'application/json' })
 
-    // NOTE: FracResponseParserUtil.parseApiResponse's generic "nested candidate" scan also
-    // reads a Blob's own `.text` property (a function reference) as a candidate before
-    // readErrorPayload's dedicated Blob branch gets a chance to call `.text()`. That first,
-    // unintended access must be neutralized here (source file is out of scope for this fix)
-    // so the later legitimate `rawError.text()` call in readErrorPayload still works.
-    const originalText = blob.text.bind(blob)
-    let accessCount = 0
-    Object.defineProperty(blob, 'text', {
-      get: () => {
-        accessCount += 1
-        return accessCount === 1 ? undefined : originalText
-      },
-    })
-
     const parsed = await FracResponseParserUtil.readErrorPayload({ error: blob })
     expect(parsed?.responseCode).toBe('CLIENT_ERROR')
     expect(parsed?.params?.errmsg).toBe('invalid file')

--- a/project/ws/app/src/lib/routes/home/resolvers/users-list-resolve.service.spec.ts
+++ b/project/ws/app/src/lib/routes/home/resolvers/users-list-resolve.service.spec.ts
@@ -25,7 +25,7 @@ describe('UsersListResolve', () => {
     usersService.getAllUsers.mockReturnValue(of({ result: 'ok' }))
     resolver.resolve({} as any, {} as any).subscribe(res => {
       expect(res).toEqual({ data: { result: 'ok' }, error: null })
-      const [filterObj] = usersService.getAllUsers.mock.calls[0]
+      const [filterObj] = usersService.getAllUsers.mock.calls[0] as [any]
       expect(filterObj.request.filters.rootOrgId).toBe('org-1')
       done()
     })
@@ -44,7 +44,7 @@ describe('UsersListResolve', () => {
     configSvc.unMappedUser = undefined
     usersService.getAllUsers.mockReturnValue(of({}))
     resolver.resolve({} as any, {} as any).subscribe(() => {
-      const [filterObj] = usersService.getAllUsers.mock.calls[0]
+      const [filterObj] = usersService.getAllUsers.mock.calls[0] as [any]
       expect(filterObj.request.filters.rootOrgId).toBeUndefined()
       done()
     })

--- a/project/ws/app/src/lib/routes/home/routes/workallocation/workallocation.component.spec.ts
+++ b/project/ws/app/src/lib/routes/home/routes/workallocation/workallocation.component.spec.ts
@@ -1,3 +1,8 @@
+// ngx-export-as pulls in html2pdf.js, whose CJS bundle statically imports ESM jspdf
+// internals that Jest can't parse. Mock it out before the component (which imports
+// ExportAsService directly) gets loaded.
+jest.mock('ngx-export-as', () => ({ ExportAsService: jest.fn() }))
+
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { NO_ERRORS_SCHEMA } from '@angular/core'
 import { MatDialog } from '@angular/material/dialog'

--- a/project/ws/app/src/lib/routes/workallocation-v2/components/competency-labels/competency-labels.component.spec.ts
+++ b/project/ws/app/src/lib/routes/workallocation-v2/components/competency-labels/competency-labels.component.spec.ts
@@ -566,10 +566,10 @@ describe('CompetencyLabelsComponent', () => {
       })
       component.competencySelected({ option: { value: { name: 'directVal' } } }, 0)
       // When localId is falsy, the component's `if (localOd)` branch is skipped entirely,
-      // so oldcompData stays null and the dialog only receives the fallback `children` list
-      // (event.option.value is not actually used as dialog data in this branch).
+      // so oldcompData stays null and `data: oldcompData ? {...} : event.option.value`
+      // falls through to using event.option.value directly as the dialog data.
       expect(dialogMock.open).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
-        data: { children: ['L1', 'L2'] },
+        data: { name: 'directVal' },
       }))
     })
 

--- a/project/ws/app/src/lib/routes/workallocation-v2/routes/published-allocations/published-allocations.component.spec.ts
+++ b/project/ws/app/src/lib/routes/workallocation-v2/routes/published-allocations/published-allocations.component.spec.ts
@@ -1,3 +1,8 @@
+// ngx-export-as pulls in html2pdf.js, whose CJS bundle statically imports ESM jspdf
+// internals that Jest can't parse. Mock it out before the component (which imports
+// ExportAsService directly) gets loaded.
+jest.mock('ngx-export-as', () => ({ ExportAsService: jest.fn() }))
+
 import { of, Subject } from 'rxjs'
 import { PublishedAllocationsComponent } from './published-allocations.component'
 

--- a/project/ws/app/src/lib/routes/workallocation/routes/create-workallocation/create-workallocation.component.spec.ts
+++ b/project/ws/app/src/lib/routes/workallocation/routes/create-workallocation/create-workallocation.component.spec.ts
@@ -1,3 +1,8 @@
+// ngx-export-as pulls in html2pdf.js, whose CJS bundle statically imports ESM jspdf
+// internals that Jest can't parse. Mock it out before the component (which imports
+// ExportAsService directly) gets loaded.
+jest.mock('ngx-export-as', () => ({ ExportAsService: jest.fn() }))
+
 import { UntypedFormBuilder } from '@angular/forms'
 import { of } from 'rxjs'
 import { CreateWorkallocationComponent } from './create-workallocation.component'

--- a/project/ws/app/src/lib/routes/workallocation/routes/update-workallocation/update-workallocation.component.spec.ts
+++ b/project/ws/app/src/lib/routes/workallocation/routes/update-workallocation/update-workallocation.component.spec.ts
@@ -1,3 +1,8 @@
+// ngx-export-as pulls in html2pdf.js, whose CJS bundle statically imports ESM jspdf
+// internals that Jest can't parse. Mock it out before the component (which imports
+// ExportAsService directly) gets loaded.
+jest.mock('ngx-export-as', () => ({ ExportAsService: jest.fn() }))
+
 import { UntypedFormArray, UntypedFormBuilder } from '@angular/forms'
 import { of } from 'rxjs'
 import { createSpyObj } from 'src/test-utils/create-spy-obj'

--- a/src/app/guards/login.guard.spec.ts
+++ b/src/app/guards/login.guard.spec.ts
@@ -36,7 +36,7 @@ describe('LoginGuard', () => {
 
   it('should redirect to the decoded ref query param when authenticated', () => {
     build({ isAuthenticated: true })
-    router.parseUrl.mockReturnValue('parsed-tree')
+    router.parseUrl.mockReturnValue('parsed-tree' as any)
     const next = { queryParamMap: { has: () => true, get: () => encodeURIComponent('/app/x') } }
     const result = guard.canActivate(next as any, {} as any)
     expect(router.parseUrl).toHaveBeenCalledWith('/app/x')


### PR DESCRIPTION
- login.guard.spec.ts: parseUrl mock returns a string, guard expects UrlTree — cast
- frac-response-parser.util.spec.ts: remove a broken Object.defineProperty hack on Blob.text that only fired once and swallowed the real read via its own try/catch
- list-event.component.spec.ts: jest.mock('moment') set __esModule on the actual module without a .default, so the ts-interop-wrapped default import resolved to undefined; return { __esModule: true, default: actualMoment } instead
- users-list-resolve.service.spec.ts: cast mock.calls[0] tuple to access .request
- competency-labels.component.spec.ts: corrected a wrong assumption in the test — when localId is falsy the component actually falls through to using event.option.value directly as dialog data (data: oldcompData ? {...} : event.option.value), not the fallback children array the test comment claimed
- update/create-workallocation, published-allocations, workallocation (home) specs: jest.mock('ngx-export-as') before the component import — the real module pulls in html2pdf.js, a CJS bundle that statically imports ESM jspdf internals Jest can't parse

Full suite: 248/248 suites, 3840/3841 tests passing (1 skipped)