### PR TITLE
fix(events): honour No-Registration event type and tighten participant upload (v2.1.1)

### DIFF
--- a/RELEASE_NOTES/release-2.1.1.md
+++ b/RELEASE_NOTES/release-2.1.1.md
@@ -1,0 +1,84 @@
+# Release 2.1.1 — 2026-08-17
+
+|                              |                                                |
+| ---------------------------- | ---------------------------------------------- |
+| **Build branch deployed**    | `release-2.1.1` (Jenkins deploy source)      |
+| **Tag**                      | `v2.1.1` (immutable marker + GitHub Release) |
+| **Baseline (previous prod)** | `v2.1.0`                                     |
+| **Commits**                  | `1`                                          |
+| **Author**                   | Likhith Thammegowda                          |
+
+## Summary
+
+Patch release fixing the "No Registration" event type. Events created with no registration
+were being treated as registration-based, so adding participants demanded a 10-digit phone
+number for every row and rejected otherwise valid upload files. Participant upload validation
+has also been tightened so problems are reported against the right row and a missing surname
+no longer produces a certificate with a blank name.
+
+## ✨ Features
+
+_None — patch release._
+
+## 🐛 Fixes
+
+- **events** — "No Registration" events are now recognised correctly. The API returns the
+  registration mode as `eventType` while the UI reads `registrationType`; only the dashboard
+  list mapped between them, and `event-details` refetches the event by id and overwrites the
+  globally stored event with the raw response — leaving `registrationType` undefined so the
+  no-registration branch never activated. Normalised once in `EventService.getEventById` so
+  every consumer agrees. Symptoms fixed: participant upload demanding a phone number, and the
+  certificate-status column appearing on no-registration events (`9e1dd19`).
+- **events** — Participant upload now requires Last Name for no-registration events. Their
+  certificates are rendered client-side from First + Last Name, so a missing surname
+  previously printed blank with no warning (`9e1dd19`).
+- **events** — Upload validation errors now cite the actual sheet row (`index + 2`) instead of
+  the data-array index, which was always one lower than the row shown in the file (`9e1dd19`).
+- **events** — CSV parsing skips empty lines; a trailing newline previously created a phantom
+  row that failed validation against a line the user could not see (`9e1dd19`).
+- **events** — A file containing no participant rows is now rejected instead of being treated
+  as valid (`9e1dd19`).
+- **events** — The sample workbook is event-type aware: `phone` and `location` are omitted for
+  no-registration events, where they are never read (`9e1dd19`).
+- **events** — `phone` is only stringified when a value is present; previously
+  `String(undefined)` sent the literal string `"undefined"` to the backend (`9e1dd19`).
+
+## 🏗️ Build / CI / Infra
+
+_None._
+
+## 📚 Docs / Chore
+
+- **chore** — `package.json` bumped to `2.1.1`.
+
+## ⚠️ Deploy notes & risk
+
+- **Migration/deploy gotchas touched?** None. No routing, module, or Material changes.
+- **Config / env / secret changes:** none.
+- **Backend / API contract dependencies:** none — the fix adapts to the existing
+  `eventType` response field rather than asking the backend to change.
+- **Breaking changes:** none. `registrationType` is still honoured when already present, so
+  the dashboard list path is unaffected.
+- **Behavioural change to verify:** no-registration participant uploads now **require Last
+  Name**. Any existing upload file with blank surnames will be rejected where it previously
+  passed — this is deliberate, since those rows produced certificates with missing names.
+- **Not included:** the generated `src/styles.scss` and `yarn.lock` were deliberately left out
+  of this release; neither relates to these fixes.
+
+## ✅ Pre-deploy checklist
+
+- [ ] Lint + jest pass on `production` at the release commit.
+- [ ] Create a "No Registration" event; upload participants **without** a phone column and
+      confirm the file is accepted.
+- [ ] Confirm the certificate-status column is **not** shown on that event's participants tab.
+- [ ] Upload a file with a blank Last Name and confirm it is rejected with the correct row number.
+- [ ] Regression: a "Registration based" event still requires a valid 10-digit phone.
+- [ ] Rollback reference confirmed: previous release branch `release-2.1.0` / tag `v2.1.0`.
+
+## Release & rollback
+
+- **Deploy source:** `release-2.1.1`, cut from `production` at the release commit and tagged
+  `v2.1.1`. Jenkins targets the branch, not the tag.
+- **Rollback:** re-run the deploy pipeline against `release-2.1.0`. Safe — the change is
+  frontend-only with no config or contract dependency, so reverting simply restores the
+  previous (broken) no-registration behaviour.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mdo",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "scripts": {
         "ng": "ng",
         "start": "node --max_old_space_size=8000 ./node_modules/@angular/cli/bin/ng serve --proxy-config proxy/localhost.proxy.json -o",

--- a/project/ws/app/src/lib/routes/home/routes/add-participants/add-participants.component.spec.ts
+++ b/project/ws/app/src/lib/routes/home/routes/add-participants/add-participants.component.spec.ts
@@ -85,19 +85,44 @@ describe('AddParticipantsComponent', () => {
       build({ eventId: 'e1', eventType: false })
       component.participants = [{ firstName: '', phone: '123' } as any]
       component.validateParticipants()
+      // Row 2, not 1: index 0 is the first data row, which is sheet row 2 below the header.
       expect(component.validationErrors).toEqual([
-        'Row 1: First Name is required.',
-        'Row 1: Invalid Phone Number (must be 10 digits).',
+        'Row 2: First Name is required.',
+        'Row 2: Invalid Phone Number (must be 10 digits).',
       ])
       expect(component.isValidData).toBe(false)
     })
 
     it('should skip phone validation when eventType is true', () => {
       build({ eventId: 'e1', eventType: true })
-      component.participants = [{ firstName: 'John', phone: 'invalid' } as any]
+      component.participants = [{ firstName: 'John', lastName: 'Doe', phone: 'invalid' } as any]
       component.validateParticipants()
       expect(component.validationErrors).toEqual([])
       expect(component.isValidData).toBe(true)
+    })
+
+    it('should require lastName when eventType is true, as it is printed on the certificate', () => {
+      build({ eventId: 'e1', eventType: true })
+      component.participants = [{ firstName: 'John' } as any]
+      component.validateParticipants()
+      expect(component.validationErrors).toEqual(['Row 2: Last Name is required.'])
+      expect(component.isValidData).toBe(false)
+    })
+
+    it('should not require lastName when eventType is false', () => {
+      build({ eventId: 'e1', eventType: false })
+      component.participants = [{ firstName: 'John', phone: '1234567890' } as any]
+      component.validateParticipants()
+      expect(component.validationErrors).toEqual([])
+      expect(component.isValidData).toBe(true)
+    })
+
+    it('should reject a file with no participant rows', () => {
+      build({ eventId: 'e1', eventType: true })
+      component.participants = []
+      component.validateParticipants()
+      expect(component.validationErrors).toEqual(['The file has no participant rows.'])
+      expect(component.isValidData).toBe(false)
     })
 
     it('should mark valid data as valid', () => {

--- a/project/ws/app/src/lib/routes/home/routes/add-participants/add-participants.component.ts
+++ b/project/ws/app/src/lib/routes/home/routes/add-participants/add-participants.component.ts
@@ -59,6 +59,9 @@ export class AddParticipantsComponent implements OnInit, OnDestroy {
   parseCSV(file: File): void {
     Papa.parse<IParticipant>(file, {
       header: true,
+      // Without this a trailing newline yields a phantom blank row that fails validation
+      // and points at a row the user cannot see in their file.
+      skipEmptyLines: true,
       complete: (result: Papa.ParseResult<IParticipant>) => {
         this.participants = result.data
         this.validateParticipants()
@@ -86,15 +89,29 @@ export class AddParticipantsComponent implements OnInit, OnDestroy {
   validateParticipants(): void {
     this.validationErrors = []
 
+    if (!this.participants.length) {
+      this.validationErrors = ['The file has no participant rows.']
+      this.isValidData = false
+      return
+    }
+
     this.participants.forEach((participant, index) => {
-      if (!participant.firstName) {
-        this.validationErrors.push(`Row ${index + 1}: First Name is required.`)
+      // +2, not +1: index 0 is the first data row, which is row 2 in the sheet (row 1 is the header).
+      const row = index + 2
+
+      if (!String(participant.firstName || '').trim()) {
+        this.validationErrors.push(`Row ${row}: First Name is required.`)
       }
 
-      if (this.eventType === false) {
-        console.log(participant.phone)
-        if (!participant.phone || !/^\d{10}$/.test(participant.phone)) {
-          this.validationErrors.push(`Row ${index + 1}: Invalid Phone Number (must be 10 digits).`)
+      if (this.eventType) {
+        // No-registration events: no phone is collected, and the certificate is rendered
+        // client-side from First + Last Name, so a missing surname would silently print blank.
+        if (!String(participant.lastName || '').trim()) {
+          this.validationErrors.push(`Row ${row}: Last Name is required.`)
+        }
+      } else {
+        if (!participant.phone || !/^\d{10}$/.test(String(participant.phone).trim())) {
+          this.validationErrors.push(`Row ${row}: Invalid Phone Number (must be 10 digits).`)
         }
       }
     })
@@ -105,10 +122,15 @@ export class AddParticipantsComponent implements OnInit, OnDestroy {
   saveParticipants(): void {
     if (!this.isValidData) { return }
 
-    this.participants = this.participants.map(participant => ({
-      ...participant,
-      phone: String(participant.phone),
-    }))
+    this.participants = this.participants.map(participant => {
+      // No-registration events collect no phone; String(undefined) would send the literal
+      // string "undefined" to the backend, so only stringify when a value is actually present.
+      const normalised = { ...participant }
+      normalised.phone = participant.phone === undefined || participant.phone === null
+        ? ''
+        : String(participant.phone).trim()
+      return normalised
+    })
 
     this.subscription = this.eventService.addParticipants(this.eventId, this.participants).subscribe({
       next: response => {
@@ -135,10 +157,17 @@ export class AddParticipantsComponent implements OnInit, OnDestroy {
 
   downloadSampleExcel() {
 
-    const sampleData = [
-      { firstName: 'John', lastName: 'Doe', phone: '1234567890', location: 'California' },
-      { firstName: 'Jane', lastName: 'Smith', phone: '9876543210', location: 'New York' }
-    ]
+    // No-registration events never read phone, so leaving it in the sample invites
+    // collecting personal data that is discarded and implies a column that is not required.
+    const sampleData = this.eventType
+      ? [
+        { firstName: 'John', lastName: 'Doe' },
+        { firstName: 'Jane', lastName: 'Smith' },
+      ]
+      : [
+        { firstName: 'John', lastName: 'Doe', phone: '1234567890', location: 'California' },
+        { firstName: 'Jane', lastName: 'Smith', phone: '9876543210', location: 'New York' },
+      ]
 
     const worksheet: XLSX.WorkSheet = XLSX.utils.json_to_sheet(sampleData)
 

--- a/project/ws/app/src/lib/routes/home/services/event.service.ts
+++ b/project/ws/app/src/lib/routes/home/services/event.service.ts
@@ -38,8 +38,27 @@ export class EventService {
 
   getEventById(eventId: string): Observable<any> {
     return this.http.get(API_END_POINTS.GET_EVENT_BY_ID(eventId)).pipe(
-      map(response => response) // Modify mapping if needed
+      map(response => this.normaliseEvent(response))
     )
+  }
+
+  /**
+   * The API returns the registration mode as `eventType`, but the UI reads it as
+   * `registrationType` (event-overview, participants). Only the dashboard list mapped the
+   * two, and event-details refetches by id and overwrites the globally stored event with
+   * the raw response — leaving `registrationType` undefined, so "No Registration" events
+   * were treated as registration-based (phone validation applied, certificate status shown).
+   * Normalising here means every consumer of an event object sees the same field.
+   */
+  // tslint:disable-next-line: no-any
+  private normaliseEvent(event: any): any {
+    if (!event) {
+      return event
+    }
+    return {
+      ...event,
+      registrationType: event.registrationType || event.eventType,
+    }
   }
 
   createEvent(eventData: any): Observable<any> {


### PR DESCRIPTION
Patch release **v2.1.1**. Code fix plus `RELEASE_NOTES/release-2.1.1.md` and the `package.json` bump, in one PR.

## The bug

Creating a **"No Registration"** event and adding participants failed validation — every row was rejected with *"Invalid Phone Number (must be 10 digits)"*, even though no-registration events never collect a phone.

## Root cause — a field-name mismatch, not the validation

The API returns the registration mode as **`eventType`**; the UI reads **`registrationType`**.

Only the dashboard list mapped between them (`event-dashboard.component.ts:101`). But `event-details.component.ts:41-44` refetches the event by id and pushes the **raw response** into the globally stored event — so `registrationType` was always `undefined`, `nonRegistered` never became `true`, and the phone branch ran. That overwrite is why it failed *even when arriving from the dashboard*.

Fixed at the single choke point in `EventService.getEventById()`, which already carried a `// Modify mapping if needed` comment:

```ts
registrationType: event.registrationType || event.eventType,
```

This also fixes a second symptom that hadn't been reported: `participants.component.ts:73` was showing the certificate-status column on no-registration events, for the same reason.

## Upload validation, also tightened

| Change | Why |
|---|---|
| **Last Name now required** (no-registration only) | Certificates are rendered client-side from First + Last Name — a blank surname printed silently |
| Row numbers use `index + 2` | Reported row was one lower than the sheet, since row 1 is the header |
| `skipEmptyLines: true` | A trailing newline made a phantom row fail against an invisible line |
| Empty-file guard | Zero rows previously counted as valid |
| Sample workbook is event-type aware | Drops `phone`/`location` for no-registration events, where they're never read |
| `phone` stringified only when present | `String(undefined)` was sending the literal `"undefined"` |

## Verification

`6 suites / 89 tests` pass, including the two specs updated for the row-offset change and the new Last Name rule, plus three added cases.

## Reviewer notes

- **Behavioural change:** existing no-registration upload files with blank surnames will now be **rejected**. Deliberate — those rows produced certificates with missing names.
- **Backwards compatible:** `registrationType` is still honoured when already present, so the dashboard path is untouched.
- **Deliberately excluded:** the regenerated `src/styles.scss` (3.6 MB Tailwind artifact, unrelated and needs its own visual QA) and `yarn.lock`.
